### PR TITLE
feat(slides): Add Reveal.js format for existing presentation

### DIFF
--- a/docs/plans/001-reveal-js-integration.md
+++ b/docs/plans/001-reveal-js-integration.md
@@ -1,0 +1,439 @@
+# Reveal.js Integration Implementation Plan
+
+**Plan ID**: 001  
+**Created**: 2025-01-27  
+**Status**: Ready for Implementation  
+
+## Overview
+
+This plan outlines the implementation of Reveal.js slides integration into the existing Remix portfolio website. The goal is to enable local hosting of presentation slides while leveraging Reveal.js's native Markdown support and maintaining the existing architecture.
+
+## Key Discovery: Native Markdown Support
+
+Through research, we discovered that Reveal.js has **built-in Markdown support** that eliminates the need for custom parsing:
+
+- ✅ Reveal.js includes native Markdown plugin using 'marked' library
+- ✅ Supports external Markdown file loading via `data-markdown` attributes
+- ✅ Configurable slide separators (`---` for horizontal, `--` for vertical)
+- ✅ Built-in syntax highlighting integration
+- ❌ **No custom slideParser.ts needed** - Reveal.js handles everything!
+
+## Current State Analysis
+
+### Dependencies Status
+- ✅ `reveal.js` v5.2.1 already installed
+- ✅ `@types/reveal.js` v5.2.0 already installed
+- ✅ `rehype-highlight` v7.0.0 for code syntax highlighting
+- ✅ `highlight.js` v11.9.0 available
+- ✅ Remix MDX support already configured
+
+### Architecture Foundation
+- **Framework**: Remix with TypeScript
+- **Styling**: Tailwind CSS with custom theme system
+- **Routing**: File-based routing with layout patterns
+- **Content**: MDX support for blog posts
+- **Theme**: Dark/light mode with anti-flash system
+
+## Implementation Phases
+
+### Phase 1: Core Infrastructure (Week 1)
+
+#### 1.1 Data Models
+
+**File**: `app/models/slides.ts`
+
+```typescript
+export type SlidePresentation = {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  event?: string;
+  markdownPath: string; // Path to .md file for Reveal.js
+  assetsPath?: string;  // Path to assets directory
+  theme?: "light" | "dark" | "auto";
+  revealConfig?: {
+    transition?: string;
+    backgroundTransition?: string;
+    controls?: boolean;
+    progress?: boolean;
+    center?: boolean;
+    touch?: boolean;
+  };
+};
+
+export type SlideMetadata = {
+  title: string;
+  description: string;
+  date: string;
+  event?: string;
+  author?: string;
+  theme?: "light" | "dark" | "auto";
+  revealConfig?: SlidePresentation["revealConfig"];
+};
+```
+
+#### 1.2 Reveal.js React Wrapper
+
+**File**: `app/components/slides/RevealSlides.tsx`
+
+**Key Features**:
+- React integration using useEffect pattern
+- Native Markdown plugin initialization
+- Theme-aware configuration
+- Proper cleanup and error handling
+- External Markdown file loading
+
+**Implementation Pattern**:
+```typescript
+useEffect(() => {
+  if (deckRef.current) return; // Prevent double initialization
+
+  deckRef.current = new Reveal(deckDivRef.current!, {
+    plugins: [RevealMarkdown, RevealHighlight],
+    markdown: {
+      smartypants: true,
+    },
+    // Theme and responsive configuration
+  });
+
+  deckRef.current.initialize();
+
+  return () => {
+    deckRef.current?.destroy();
+    deckRef.current = null;
+  };
+}, []);
+```
+
+#### 1.3 Theme Integration Component
+
+**File**: `app/components/slides/SlideTheme.tsx`
+
+**Responsibilities**:
+- Extend existing theme context for slides
+- Dynamic Reveal.js theme switching via `Reveal.configure()`
+- CSS variable mapping between site theme and Reveal.js
+- Listen to theme context changes and update Reveal.js accordingly
+
+#### 1.4 Slide Loader Component
+
+**File**: `app/components/slides/SlideLoader.tsx`
+
+**Responsibilities**:
+- Handle loading external Markdown files
+- **No parsing needed** - pass file paths to Reveal.js
+- Asset path resolution for images/videos
+- Error handling for missing files
+
+### Phase 2: Routing & Navigation (Week 2)
+
+#### 2.1 Route Structure
+
+**File**: `app/routes/_layout.slides.tsx`
+- List all available slide presentations
+- Integration with existing talks data
+- Filter and search functionality
+- Consistent layout with site design
+
+**File**: `app/routes/slides.$slug.tsx`
+- Load specific slide presentation
+- **Simple implementation**: Load .md file path and pass to Reveal.js
+- SEO meta tags from frontmatter (minimal parsing for metadata only)
+- Error boundaries for graceful fallbacks
+
+#### 2.2 Navigation Integration
+
+**Updates to existing files**:
+- Update talks pages to link to local slides when available
+- Add slides section to main navigation
+- Implement slide navigation controls with keyboard support
+- URL fragment handling for deep-linking to specific slides
+
+### Phase 3: Content Structure & Migration (Week 3)
+
+#### 3.1 Content Directory Structure
+
+```
+app/data/slides/
+├── jsconf-asia-2019/
+│   ├── slides.md          # Native Reveal.js Markdown
+│   ├── assets/            # Images, videos, etc.
+│   │   ├── state-machine.png
+│   │   └── demo-video.mp4
+│   └── metadata.json      # Title, description, date
+├── web-constraints/
+│   ├── slides.md
+│   ├── assets/
+│   │   ├── architecture-diagram.png
+│   │   └── performance-chart.jpg
+│   └── metadata.json
+├── reliable-tests-with-ai/
+│   ├── slides.md
+│   ├── assets/
+│   │   ├── test-pyramid.png
+│   │   └── ai-workflow.gif
+│   └── metadata.json
+└── ...
+```
+
+#### 3.2 Markdown Slide Format
+
+Using Reveal.js native Markdown syntax:
+
+```markdown
+# Slide Title
+
+Content here with **bold** and *italic* text
+
+---
+
+## Horizontal Slide
+
+- Bullet point 1
+- Bullet point 2
+
+--
+
+### Vertical Slide
+
+Nested content under the previous slide
+
+---
+
+## Code Example
+
+```javascript
+const example = "syntax highlighted code";
+```
+
+Note: This is a speaker note that won't be visible
+
+---
+
+## Image Slide
+
+![Alt text](assets/image.png)
+```
+
+#### 3.3 Metadata Format
+
+**File**: `metadata.json` in each slide directory
+
+```json
+{
+  "title": "State Machines Meet React Hooks",
+  "description": "A journey in using State Machines along with React Hooks",
+  "date": "2019-06-15",
+  "event": "JSConf Asia 2019",
+  "author": "Zain Fathoni",
+  "theme": "auto",
+  "revealConfig": {
+    "transition": "slide",
+    "backgroundTransition": "fade",
+    "controls": true,
+    "progress": true,
+    "center": true,
+    "touch": true
+  }
+}
+```
+
+### Phase 4: Advanced Features & Polish (Week 4)
+
+#### 4.1 Reveal.js Configuration
+
+**Native Markdown Plugin Setup**:
+```javascript
+Reveal.initialize({
+  plugins: [RevealMarkdown, RevealHighlight, RevealNotes],
+  
+  // Markdown configuration
+  markdown: {
+    smartypants: true,
+  },
+  
+  // Highlight.js configuration (integrate with existing)
+  highlight: {
+    highlightOnLoad: false, // Use existing highlight.js setup
+  },
+  
+  // Theme integration
+  theme: getCurrentTheme(),
+  
+  // Responsive design
+  width: 960,
+  height: 700,
+  margin: 0.04,
+  minScale: 0.2,
+  maxScale: 2.0,
+  
+  // Navigation
+  hash: true,
+  controls: true,
+  progress: true,
+  center: true,
+  touch: true,
+  
+  // Transitions
+  transition: "slide",
+  backgroundTransition: "fade",
+});
+```
+
+#### 4.2 Advanced Features
+
+- **Speaker Notes**: Using Reveal.js `Note:` syntax in Markdown
+- **Fullscreen/Embedded Modes**: Toggle between embedded and fullscreen presentation
+- **Theme Synchronization**: Dynamic theme switching with site theme context
+- **Navigation Controls**: Custom controls integrated with site design
+- **Keyboard Support**: Full keyboard navigation support
+- **Progress Indicators**: Slide counters and progress bars
+
+#### 4.3 Styling & Responsive Design
+
+**Custom Reveal.js Theme**:
+- Match existing site typography and color scheme
+- Integrate with Tailwind CSS variables
+- Responsive design for mobile/desktop
+- Dark/light mode transitions
+
+**CSS Integration**:
+- Extend `app/tailwind.css` with Reveal.js custom styles
+- Use CSS custom properties for theme variables
+- Maintain consistent design language
+
+### Phase 5: Performance & SEO (Week 4)
+
+#### 5.1 Performance Optimization
+
+- **Lazy Loading**: Load slide assets on demand
+- **Code Splitting**: Bundle Reveal.js separately
+- **Asset Optimization**: Optimize images and videos for web
+- **Preloading**: Strategic preloading of next slides
+
+#### 5.2 SEO & Accessibility
+
+- **Meta Tags**: Proper SEO meta tags for slide pages
+- **Structured Data**: JSON-LD for presentation metadata
+- **Accessibility**: WCAG compliance with keyboard navigation
+- **Sitemap**: Include slide pages in sitemap generation
+
+## Technical Implementation Details
+
+### File Structure (Final)
+
+```
+app/
+├── components/
+│   └── slides/
+│       ├── RevealSlides.tsx      # Main wrapper (simplified)
+│       ├── SlideTheme.tsx        # Theme integration
+│       ├── SlideLoader.tsx       # File loading (no parsing)
+│       └── SlideNavigation.tsx   # Custom navigation controls
+├── routes/
+│   ├── _layout.slides.tsx        # Slides listing page
+│   └── slides.$slug.tsx          # Individual slide presentation
+├── data/
+│   └── slides/                   # Slide content directory
+│       ├── jsconf-asia-2019/
+│       │   ├── slides.md         # Native Reveal.js Markdown
+│       │   ├── assets/
+│       │   └── metadata.json
+│       ├── web-constraints/
+│       └── reliable-tests-with-ai/
+├── models/
+│   └── slides.ts                 # Type definitions and data
+└── utils/
+    └── slideLoader.ts            # Utility functions for loading
+```
+
+### Integration Points
+
+1. **Theme System**: Extend existing `app/contexts/theme.tsx`
+2. **Component Library**: Reuse `Container`, `Header`, `Footer` components
+3. **Syntax Highlighting**: Leverage existing `rehype-highlight` setup
+4. **Asset Management**: Follow existing image optimization patterns
+5. **Routing**: Build on existing layout pattern conventions
+
+### Key Advantages of This Approach
+
+- ✅ **Simplified Implementation**: No custom Markdown parsing
+- ✅ **Leverages Reveal.js Strengths**: Battle-tested Markdown support
+- ✅ **Faster Development**: Less custom code to maintain
+- ✅ **Better Compatibility**: Standard Reveal.js features work out of box
+- ✅ **Easier Content Authoring**: Standard Markdown syntax
+- ✅ **Future-Proof**: Aligned with Reveal.js ecosystem
+
+## Migration Strategy
+
+### Immediate Candidates for Local Hosting
+
+1. **"Writing Reliable Tests for React using AI"** (latest, GitHub-hosted)
+2. **"Embracing #nobuild in Modern Web"** (recent, multiple events)
+3. **"State Machines Meet React Hooks"** (GitHub repo available)
+
+### Content Migration Process
+
+1. **Extract existing slide content** from external sources
+2. **Convert to Reveal.js Markdown format** using `---` separators
+3. **Optimize assets** for web delivery
+4. **Create metadata.json** files for each presentation
+5. **Test responsive design** across devices
+6. **Validate accessibility** compliance
+
+### Backward Compatibility
+
+- Keep existing external links functional in talks model
+- Add `hasLocalSlides` flag to Talk type
+- Gradual migration without breaking existing functionality
+- Fallback to external links if local slides fail to load
+
+## Success Criteria
+
+- [ ] All 30+ requirements from EARS document satisfied
+- [ ] Native Reveal.js Markdown support implemented
+- [ ] Seamless theme integration (dark/light mode)
+- [ ] Mobile-responsive slide presentations
+- [ ] Backward compatibility with existing talks
+- [ ] Fast loading and smooth transitions
+- [ ] SEO optimized with proper meta tags
+- [ ] Accessibility compliance (WCAG standards)
+- [ ] Code splitting and performance optimization
+
+## Risk Assessment & Mitigation
+
+### Technical Risks
+- **Integration Complexity**: Mitigated by leveraging native Reveal.js features
+- **Performance Impact**: Addressed through code splitting and lazy loading
+- **Theme Integration**: Simplified by using Reveal.js configure API
+
+### Content Risks
+- **Migration Effort**: Phased approach starting with 3 presentations
+- **Asset Management**: Automated optimization and proper folder structure
+- **Maintenance Overhead**: Reduced by using standard Reveal.js patterns
+
+### User Experience Risks
+- **Loading Performance**: Mitigated by preloading and optimization
+- **Mobile Experience**: Addressed through responsive design testing
+- **Accessibility**: Ensured through WCAG compliance testing
+
+## Timeline
+
+- **Week 1**: Core infrastructure (models, components, theme integration)
+- **Week 2**: Routing and navigation (slides routes, navigation integration)
+- **Week 3**: Content migration (3 presentations, testing, optimization)
+- **Week 4**: Polish and performance (styling, SEO, accessibility)
+
+## Next Steps
+
+1. **Start with Phase 1**: Create data models and core components
+2. **Test Early**: Validate Reveal.js integration with simple example
+3. **Iterate Quickly**: Get basic functionality working before advanced features
+4. **Document Progress**: Update this plan as implementation progresses
+
+---
+
+**Status**: Ready for implementation  
+**Dependencies**: All required packages already installed  
+**Approval**: Obtained from user for streamlined approach

--- a/public/paket-hemat-claude-code-reveal.md
+++ b/public/paket-hemat-claude-code-reveal.md
@@ -1,0 +1,193 @@
+# Paket Hemat Claude Code
+
+Membangun alur kerja dan belajar yang efektif ⬆️ dan efisien 💰 dalam penggunaan AI
+
+---
+
+## Perkenalan
+
+![Profile](assets/zain-1280.jpeg) <!-- width="300" style="float: left; margin-right: 20px;" -->
+
+https://www.zainfathoni.com/about
+
+- 📍 Jember ➡️ Bandung ➡️ SG ➡️ Jogja
+- 🔨 Backend ➡️ Manager ➡️ Frontend
+- 📅 1 bulan++ menggunakan Claude Code
+
+---
+
+## Agenda
+
+1. **Membangun kesadaran bersama AI**
+2. **Cara minimalisir halusinasi AI**
+3. **Alur kerja memanfaatkan Claude Code**
+4. **Tips hemat dan efektif dengan Claude Code**
+
+---
+
+## 1. Membangun Kesadaran Bersama AI
+
+<!-- .slide: data-background-image="assets/iron-man.png" data-background-size="contain" data-background-position="right" -->
+
+[The 70% Problem](https://addyo.substack.com/p/the-70-problem-hard-truths-about)
+
+- Kita harus **sadar** (_conscious_) atas apa yang sedang terjadi
+- Kita pastikan AI **napak tanah** (_grounded_) dengan kenyataan
+
+---
+
+## 2. Cara Minimalisir Halusinasi AI
+
+- 🧠 Context Engineering
+- 🔨 Memilih Tech Stack yang ramah AI
+- 🛡️ Trust, but Verify
+- 🧪 Pengujian Otomatis
+
+---
+
+## 🧠 Context Engineering
+
+<!-- .slide: data-background-image="assets/prompt-vs-context-engineering.webp" data-background-size="contain" data-background-position="right" -->
+
+[Context Engineering: Bringing Engineering Discipline to Prompts](https://addyo.substack.com/p/context-engineering-bringing-engineering)
+
+- ⌨️ User Input
+- 📚 Retrieved Knowledge
+- 💬 Prior Conversation
+- 🔨 Tool Outputs
+
+---
+
+## 🔨 Memilih Tech Stack yang Ramah AI
+
+[How to make your tech stack AI-friendly 📏](https://refactoring.fm/p/how-to-design-your-tech-stack-for)
+
+- 🧠 **AI sukses di mana manusia sukses**
+- 🔧 **Buat batasan-batasan**
+- 💻 **Semuanya sebagai kode**
+- 🎯 **Batasi konteks**
+- 🤖 **Desain untuk adopsi AI**
+
+---
+
+## ❌ Ketika AI Bermasalah
+
+### Jebakan Umum
+
+- Instruksi yang kabur → hasil yang tidak konsisten
+- Konteks yang hilang → halusinasi
+- Terlalu bergantung → kehilangan kontrol
+- Contoh nyata kegagalan saya dalam membuat slide ini kemarin
+  - 🙈 https://app.warp.dev/block/K5VB2RoKQHyki2Erjub0fU
+
+---
+
+## ❌ Contoh Kasus Kegagalan AI
+
+### Belajar dari Kesalahan Orang Lain
+
+- https://x.com/albertadevs/status/1947095566736904562
+- https://x.com/anothercohen/status/1948878534262575430
+  - https://x.com/spaniard_reject/status/1948807698947981486
+- https://www.pcmag.com/news/vibe-coding-fiasco-replite-ai-agent-goes-rogue-deletes-company-database
+
+---
+
+## 🛡️ Trust, but Verify
+
+[The "Trust, But Verify" Pattern For AI-Assisted Engineering](https://addyo.substack.com/p/the-trust-but-verify-pattern-for)
+
+### Strategi Validasi
+
+- ✅ **Selalu review output AI**
+- 🧪 Terapkan pengujian otomatis
+- 👥 Jangan lupakan proses peer review
+- 📊 Terapkan standar kualitas metrik
+
+https://x.com/zainfathoni/status/1946533504252289377
+
+---
+
+## 🧪 Pengujian Otomatis
+
+- ⚙️ Otomasi pengujian
+- 🚨 Pengawasan berkelanjutan
+
+### 🔧 Tools
+
+- 🎭 Playwright MCP
+- 🧪 Vitest
+- 📋 Storybook
+
+---
+
+## 3. Alur Kerja Memanfaatkan Claude Code
+
+### Rencana Berbasis Markdown
+
+- 📋 **Perencanaan terstruktur**
+- 🎯 Tujuan yang jelas
+- 📈 Pelacakan progress
+- 🔄 Perbaikan iteratif
+
+---
+
+## 📋 Contoh: Specs dari Kiro
+
+### 3 File Utama
+
+- 📝 **requirements.md** - EARS notation untuk requirement yang testable
+- 🎨 **design.md** - Arsitektur teknis dan data flow
+- 📋 **tasks.md** - Rencana implementasi yang detail dan trackable
+
+https://kiro.dev/docs/specs/concepts/
+
+---
+
+## 4. Tips Hemat dan Efektif dengan Claude Code
+
+<!-- .slide: data-background-image="assets/ccusage-example.png" data-background-size="contain" data-background-position="right" -->
+
+- 💰 **Output token itu mahal**
+- 📋 SELALU gunakan `⏸️ plan mode`
+- 🎯 Prompt yang spesifik dan ringkas
+- 🔄 Rangkum pola berulang
+- 🖥️ Pantau dengan [ccusage](https://ccusage.com/)
+
+---
+
+## Strategi Plan Mode
+
+### Alur Kerja Efisien
+
+1. 📋 **Mulai dengan `⏸️ plan mode`**
+2. 🎯 Definisikan tujuan yang jelas
+3. 🔄 Iterasi pada requirement
+4. ⚡ Eksekusi dengan efisien
+
+---
+
+## Kesimpulan
+
+- 🧠 **Bangun kesadaran AI** - AI sukses di mana manusia sukses
+- 🔨 **Buat tech stack AI-friendly** - Constraints, code, konteks terbatas
+- 🛡️ **Percaya tapi verifikasi** - Review output + testing otomatis
+- 📋 **Gunakan `⏸️ plan mode`** - Hemat token dengan perencanaan terstruktur
+- 🧪 **Integrasikan testing** - Playwright MCP untuk validasi visual
+
+---
+
+## 🙏 Terima Kasih
+
+🖥️ https://zainf.dev/paket-hemat-claude-code
+
+### Demo
+
+Mengubah slide ini menjadi interaktif dengan format Reveal.js
+
+🔗 https://github.com/zainfathoni/zainf
+
+Simak kode dan hasilnya (link menyusul): 🔗
+[VS Code Live Share](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare)
+
+Note: This concludes the presentation about efficient AI workflows using Claude Code


### PR DESCRIPTION
## Summary
- Convert existing "Paket Hemat Claude Code" slide from Marp to Reveal.js format
- Replace Marp-specific background syntax with Reveal.js data attributes
- Use standard `---` slide separators for Reveal.js compatibility
- Add speaker notes using `Note:` syntax
- Maintain all original content, emojis, and formatting

## Test plan
- [ ] Verify Reveal.js can load the converted Markdown file
- [ ] Test background images display correctly with data attributes
- [ ] Confirm slide navigation works with `---` separators
- [ ] Validate speaker notes appear in presenter mode
- [ ] Check all links and content render properly

🤖 Generated with [Claude Code](https://claude.ai/code)