### PR TITLE
chore: reduce AI-shaped patterns in flagged blog posts

### DIFF
--- a/app/routes/blog.2026-02-15.ai-tools-digest-week-2.mdx
+++ b/app/routes/blog.2026-02-15.ai-tools-digest-week-2.mdx
@@ -31,25 +31,23 @@ export const meta = () => attributes.meta;
 
 <PostHeader {...attributes} />
 
-This week's AI Tools SWE GROWTH digest (Feb 11-15) dives into model tier debates, pricing psychology, and the emerging pattern of budget subscription combos. 194 messages, plenty of Indonesian slang preserved. 🔥
+This week the group kept bouncing between two instincts: chase the best model, or build a cheaper stack that still gets the work done. Across 194 messages, the more interesting answer was usually the second one.
 
-## 🔥 Hot Takes
+## Codex Quality Still Depends on the Tier
 
-### Model Tier Wars: Does Codex Need X-High?
-
-After [leaked benchmarks](https://x.com/bilawalsidhu/status/2022571001490325791) comparing Codex performance hit the timeline, skepticism erupted:
+[Leaked benchmarks](https://x.com/bilawalsidhu/status/2022571001490325791) kicked off the familiar argument about Codex. Skepticism came first:
 
 > "yang pake Codex real kah? 🤣"
 
-The counter-argument came swiftly from actual users:
+Then actual users pushed back. Their experience was that Codex only starts to feel competitive once you pay for the higher tier.
 
 > "codex kalo gk xhigh dia gk sebagus opus - hmmm keknya codex nya harus xhigh tapi mas. kasus saya"
 
-**Consensus:** Base tier Codex underperforms vs Opus. X-high tier required for comparable quality. Pricing implications? Tier upgrades eat into cost savings.
+That makes the trade-off pretty plain. Base-tier Codex can miss the mark against Opus, but the X-high tier eats into the savings people were hoping for in the first place.
 
 ---
 
-### The Great Price Negotiation Experiment
+## Kimi Turned Pricing Into a Game
 
 [Kimi's promotional feature](https://www.kimi.com/kimiplus/sale?activity_enter_method=poster_copy_link) lets you haggle with an AI for first-month discounts. Yes, really.
 
@@ -57,233 +55,128 @@ Zain's triumphant share:
 
 > "Battled an AI for a great deal. Try topping that. - Nyoba tawar menawar sama Kimi 🤣"
 
-**Results:** $0.99 (best) to $1.50 (common). Gamification of pricing doubles as engagement mechanism.
+The results were small in dollar terms, around $0.99 to $1.50, but that was not the real point. Kimi turned pricing into engagement. People were talking about the discount flow because it was funny, while the budgeting impact was basically negligible.
 
-**Reality check:** Token consumption NOT as efficient as hoped. Quote from the field:
+The practical note from the chat was less flattering. Kimi was not as frugal as some people expected.
 
 > "Btw Kimi gk se hemat itu ternyata. Wkwkwkwk"
 
 ---
 
-## 🛠️ Tools Deep Dive
+## Chinese Models Had a Strong Week
 
-### **Kimi K2.5** — [kimi.moonshot.cn](https://kimi.moonshot.cn)
+### Kimi K2.5
 
-**Sentiment:** Positive-Cautious  
-**Mentions:** 12
+[Kimi K2.5](https://kimi.moonshot.cn) kept getting praise as a practical OpenClaw model. Built-in vision and web access mattered because it removed some of the MCP setup pain that other models still need.
 
-**What's good:**
-- Built-in vision & web search (vs Minimax needing MCP)
-- Agent swarms feature praised: "imo fitur agent swarms nya ini oke mas"
-- Interactive pricing negotiation
+The other feature people liked was agent swarms.
 
-**The catch:**
-- Token consumption higher than expected
-- Weekly limit resets at 2 PM (critical for heavy users)
-
-**Quote:**  
 > "Si kimi imo fitur agent swarms nya ini oke mas. vision n web udh built-in di modelnya"
 
----
+The main catch was operational, not philosophical: token usage could still surprise you, and the weekly limit reset time mattered if you were pushing it hard.
 
-### **GLM-5** — [chatglm.cn](https://chatglm.cn)
+### GLM-5
 
-**Sentiment:** Excited  
-**Mentions:** 7
-
-**The sembako run:**
-Free tier via [Ollama](https://ollama.com/library/glm-5) triggered a rush:
+[GLM-5](https://chatglm.cn) arrived like free groceries. Once people realized [Ollama had a library entry](https://ollama.com/library/glm-5), the chat instantly took on sembako-run energy.
 
 > "gass ada sembako lagi nih, lumayan buat nyoba2"
 
-**Key behaviors:**
-- Sharing accounts to split cost
-- More generous limits than Kimi (confirmed by multiple users)
-- Integration challenges with OpenClaw (failed attempts)
+People compared limits, talked about splitting costs, and tried to get it working inside OpenClaw. Not all of those experiments landed cleanly.
 
-**Conspiracy theory moment:**  
-When Gemini leaked Chinese model artifacts:
+The funniest moment came when Gemini leaked Chinese-model artifacts and people immediately started guessing what was actually running underneath.
 
 > "Gemini kesurupan Kimi 🤣 - Jgn bilang selama ini mereka running GLM"
 
-Echoes of Windsurf/Cursor incidents (models tuned from Chinese LLMs).
+That joke also carried some real suspicion because people have seen this pattern before.
 
----
+### Minimax M2.5
 
-### **Minimax M2.5** — [hailuo.ai](https://hailuo.ai)
+[Minimax M2.5](https://hailuo.ai) got a more measured reception. Users liked the speed and thought its tool calling held up well in longer tasks.
 
-**Sentiment:** Positive-Limited  
-**Mentions:** 5
-
-**Strengths:**
-- Speed & tool calling quality: "oke tool calling buat lama2 tasknya dan bs recover from failures"
-- Good for long-running tasks with failure recovery
-
-**Limitations:**
-- NOT multimodal yet — vision & web require MCP setup
-- Pricing starts at $100 (web tier)
-
-**Quote:**  
 > "Speed nya mas oke minimax dan kalo aku pengalaman pake, oke tool calling buat lama2 tasknya dan bs recover from failures"
 
+The drawback was obvious. It still needed MCP for vision and web, and the pricing floor was not low enough to feel impulsive.
+
 ---
 
-### **OpenClaw** — [openclaw.ai](https://openclaw.ai)
+## OpenClaw Was Useful, but Everyone Felt the Cost
 
-**Sentiment:** Complex Love-Hate  
-**Mentions:** 11
-
-**The token burn:**
+[OpenClaw](https://openclaw.ai) was one of those tools people keep using while also complaining about it. The biggest complaint was token burn.
 
 > "Openclaw boros bgt asli"
 
-**Why?**  
-Context bloat. MEMORY.md, SOUL.md, project files all included in every request:
+The explanation from the group was context bloat. Once you keep feeding `MEMORY.md`, `SOUL.md`, and project files into every request, the bill stops being theoretical.
 
 > "Mungkin depends ke contextnya pak, kalau openclaw kan include MEMORY, SOUL etc, ke dalam context jadi cukup boros"
 
-**Heavy user reality:**
-- Claude Max 20x users hitting weekly limits mid-week
-- 5-hour limits now more common constraint than weekly
+Heavy users were already shifting their mental model. The limit that mattered was often the five-hour window, not the weekly allowance.
 
-**Architecture solution suggested:**  
-Orchestrator pattern — route to sub-agents to reduce context bloat.
+The architectural answer was to route more work through orchestrators and smaller specialists instead of dragging the entire state everywhere.
 
-**Interface preference:**  
-Terminal vs Telegram comparison:
+There was also a noticeable difference in how people described terminal use versus Telegram use.
 
 > "Ini berasa beda feel nya. Kalo biasanya interface di terminal liat cli jalan ini cuman mantau report aja"
 
 ---
 
-### **Amp Code** — [ampcode.com](https://ampcode.com)
+## Amp Still Had Goodwill, Even With the Waitlist
 
-**Sentiment:** Gratitude-Dependency  
-**Mentions:** 4
+[Amp Code](https://ampcode.com) came up less often than OpenClaw, but the emotional tone was easy to read. People liked it, relied on the free path, and knew the economics were awkward.
 
-**Current state:**
-- Free tier full (waitlist)
-- Users rely on Amp Ads credits: "mengandalkan gratisan dari Amp Ads 🤣"
+The free tier was already full, some users were stretching Amp Ads credits, and the old dream of a clean $20 monthly subscription still looked unrealistic.
 
-**The subscription dream:**  
-Why can't Amp do $20/month? [Joe's explanation](https://x.com/bosonjoe/status/1911554009577541950?s=46):
+Joe's explanation for that pricing reality still held up:
 
 > "Dan selama kita berharap bisa subskreb $20/bulan, Amp ga akan pernah memenuhi harapan kita. 🤣"
 
-**Quote:**  
-> "selama model price-nya masih API token... bakal sulit klo mau subskrek. wk9"
+As long as model costs are tied to API token spend, the subscription math does not magically fix itself.
 
 ---
 
-### **Fizzy vs Beads** — Task Management Showdown
+## Fizzy vs Beads Was Really About Reliability
 
-**The scenario:** Developer choosing task tracker for agent workflows.
+This was not an abstract tooling debate. It came from someone trying to choose a task system for agent workflows.
 
-**Fizzy wins despite:**  
-No dependent tasks feature yet:
+[Fizzy](https://fizzy.do) still won mindshare even though it does not yet handle dependent tasks the way some people want.
 
 > "hmmm menarik, cuman fizzy kekurangannya dia belum bisa dependant task ya mas?"
 
-**Why Fizzy?**  
-Simpler sync vs Beads' offline-first complexity.
+The reason was simple. Fizzy looked easier to keep in sync than Beads' offline-first model.
 
-**New user reaction:**  
 > "Waaaah aku baru aja integrate beads wkwk. Ini kek waktu aku awal2 issue salah branch haha. Insha allah kucobain fizzy kl gitu."
 
 ---
 
-### **Antfarm** — [github.com/snarktank/antfarm](https://github.com/snarktank/antfarm)
+## Antfarm Joined the Multi-Agent Conversation
 
-**Sentiment:** Intrigued  
-**Mentions:** 3
-
-Recommended to Zain during agent swarms discussion:
+[Antfarm](https://github.com/snarktank/antfarm) came up because the group was already primed for multi-agent orchestration talk. It was one more sign that people are now evaluating systems, not just models.
 
 > "mas zain coba ini mas - https://github.com/snarktank/antfarm"
 
-Multi-agent orchestration framework gaining attention.
+## What Shifted This Week
+
+Last week the chat leaned more toward workflow tooling and the no-IDE movement. This week the center of gravity moved toward cost, orchestration, and how to combine several imperfect tools instead of betting everything on one premium subscription.
+
+The clearest pattern was the rise of combo stacks. Claude Max $100 plus Kimi $39. OpenClaw plus a cheaper provider. Built-in vision and web beating raw benchmark bragging rights. People were still chasing quality, but the hunt had become more pragmatic.
+
+## Things Worth Trying After This Week
+
+1. Try [Antfarm](https://github.com/snarktank/antfarm) if you are exploring multi-agent orchestration.
+2. Test [GLM-5 via Ollama](https://ollama.com/library/glm-5) while the free path still feels generous.
+3. Evaluate Kimi K2.5's agent swarms if you care more about workflow than prestige.
+4. Consider [Litestream](https://litestream.io) if you are comparing SQLite sync options with Turso.
+5. Watch the Cerebras $50/month tier as a possible Claude Max alternative.
 
 ---
 
-## 😂 Best Quotes (Indonesian Flavor)
+## Articles Shared
 
-On Codex skepticism:
-> "yang pake Codex real kah? 🤣"
-
-On Gemini's Chinese model leak:
-> "Gemini kesurupan Kimi 🤣"  
-> "Jgn bilang selama ini mereka running GLM"
-
-On GLM-5 free tier:
-> "gass ada sembako lagi nih, lumayan buat nyoba2"
-
-On OpenClaw token consumption:
-> "Openclaw boros bgt asli"
-
-On Amp Code dependency:
-> "Amp code masih mengandalkan gratisan dari Amp Ads 🤣"  
-> "sisanya ke ampcode, wkwkwkwk"
-
-On limit-hitting club:
-> "Byuh. 🤣 🤣 🙈 Kemaren 5x sempat kena limit 5 jam"
-
-On Indonesian corruption metaphor:
-> "Di Indo jangankan token LLM, BLT & MBG aja di-abuse penyakurannya. 😅"
-
-(BLT = Big Language Transformer, MBG = Model Buatan Google)
+- [Anthropic leaked benchmarks](https://x.com/btibor91/status/2022774022778556762) - Bocoran future models
+- [Kimi vs Sonnet comparison](https://llmx.tech/blog/kimi-k2-5-vs-claude-sonnet-4-5-model-comparison-2026/) - "Ini bahaya sih yah" (Kimi only matches Sonnet, not Opus)
+- [AI investment strategy reel](https://www.instagram.com/reel/DUprkuwE8Nv/?igsh=dHViMnFrdjlvdTI4) - "Harusnya negara-negara pun begini"
 
 ---
 
-## 📊 Trends
-
-### Emerging
-- **Price negotiation gamification** (Kimi model)
-- **Multi-agent orchestration** frameworks (Antfarm, agent swarms)
-- **Built-in > raw performance** (vision/web built-in vs MCP)
-- **Budget subscription combos** replacing single-provider Max tiers
-  - Example: Claude Max $100 + Kimi $39 vs full Claude Max $200
-- **Sembako culture:** rushing free tiers before they close
-
-### Continuing
-- Token cost anxiety & limit-hitting
-- Subscription fatigue vs API pricing
-- Chinese model skepticism (Gemini leak echoes Windsurf/Cursor)
-- Task management tool search (Fizzy, Beads, GitHub Issues)
-- OpenClaw context bloat discussions
-
-### Fading
-- Blind faith in model marketing (benchmarks now scrutinized)
-- Single-tool loyalty (combo subscriptions rising)
-
----
-
-## 🎯 Action Items
-
-1. **Try [Antfarm](https://github.com/snarktank/antfarm)** for multi-agent orchestration
-2. **Test [GLM-5 via Ollama](https://ollama.com/library/glm-5)** (free tier while it lasts)
-3. **Evaluate Kimi K2.5 agent swarms** feature
-4. **Consider [Litestream](https://litestream.io)** for SQLite sync (alternative to Turso)
-5. **Watch Cerebras $50/month tier** as Claude Max alternative ($50/month, 24M tokens/day)
-
----
-
-## 📚 Articles Shared
-
-- [Anthropic leaked benchmarks](https://x.com/btibor91/status/2022774022778556762) — Bocoran future models
-- [Kimi vs Sonnet comparison](https://llmx.tech/blog/kimi-k2-5-vs-claude-sonnet-4-5-model-comparison-2026/) — "Ini bahaya sih yah" (Kimi only matches Sonnet, not Opus)
-- [AI investment strategy reel](https://www.instagram.com/reel/DUprkuwE8Nv/?igsh=dHViMnFrdjlvdTI4) — "Harusnya negara-negara pun begini"
-
----
-
-## Week-over-Week Shift
-
-**Week 1:** No-IDE movement, terminal workflows, Augment Intent release  
-**Week 2:** Chinese models rising, token economics, multi-agent patterns
-
-**The shift:** From workflow tooling to cost optimization & orchestration architecture.
-
----
-
-*Digest compiled from AI Tools SWE GROWTH WhatsApp group (194 messages, Feb 11-15). Slang preserved, context enriched, insights extracted.*
+*Digest compiled from AI Tools SWE GROWTH WhatsApp group (194 messages, Feb 11-15). Slang preserved, context kept close to the original chat.*
 
 🚔 *Prowl • Weekly AI Tools Digest*

--- a/app/routes/blog.ai-tools-swe-growth-feb-4-feb-11-2026.mdx
+++ b/app/routes/blog.ai-tools-swe-growth-feb-4-feb-11-2026.mdx
@@ -33,148 +33,95 @@ export const meta = () => attributes.meta;
 
 # AI Tools SWE Growth Summary
 
-**Date Range:** February 4-11, 2026
-**Source:** WhatsApp Group "AI Tools SWE GROWTH"
-**Messages Analyzed:** 198
+Date range: February 4-11, 2026  
+Source: WhatsApp Group "AI Tools SWE GROWTH"  
+Messages analyzed: 198
 
 ---
 
-## 🛠️ Tools Deep Dive
+The chat this week felt like one long recalibration. Amp Code's free tier filled up, Augment joined the no-IDE crowd, Warp pushed further into agent orchestration, and people kept swapping notes on which tools were actually worth the token burn.
 
-### [Amp Code](https://ampcode.com)
+## What Kept Coming Up
 
-**Sentiment:** 🔥 Positive | **Mentions:** 15+
+### Amp Code: still loved, harder to get into
 
-- Free tier is currently **FULL** — waitlist active
-- `deep` mode praised for cost efficiency: "under $1 per feature vs $1.5+ for smart mode"
-- Next version highly anticipated: "sdh tdk sabar menunggu next version amp seperti apa 💪🏽🔥"
-- [Shared thread example](https://ampcode.com/threads/T-019c4acc-7e97-7109-b1fa-737740e332ce)
+Amp stayed near the center of the conversation even with the free tier marked full. People were still talking about `deep` mode as the better-value option, especially for small feature work, and there was obvious curiosity about the next release.
 
-**Key Quote:**
+The feeling was half gratitude, half dependency. As long as the free path exists, people want to keep using it.
+
 > "Selama masih bisa dapet jalur gratisan dari Amp Code, saya akan tetap setia mempromosikan. 😁"
 
----
+If you want a concrete example of the interest level, this [shared Amp thread](https://ampcode.com/threads/T-019c4acc-7e97-7109-b1fa-737740e332ce) got passed around as a reference point.
 
-### [Augment Code](https://augmentcode.com)
+### No-IDE tools keep gaining ground
 
-**Sentiment:** 🔥 Exciting
+[Augment Code](https://augmentcode.com) released Intent and instantly got grouped with the terminal-first tools. That mattered because the chat was already circling around a bigger theme: more people are comfortable leaving the IDE for certain kinds of work.
 
-- Released **"Intent"** — joining the no-IDE club
-- [Launch tweet](https://x.com/augmentcode/status/2021270140525085053)
-- Big announcement teased: "Augmentcode mau ngasih gebrakan 🤔"
+At the same time, [Warp Oz](https://www.warp.dev/oz) landed with agent orchestration support. That pushed the discussion beyond prompt engineering into coordination, delegation, and whether people were about to be left behind if they only learned the older workflows.
 
-**Key Quote:**
 > "augment sdh rilis namanya intent, sesuai yg mas blg no IDE club, wkwkwkwk"
 
----
+> "warp ngeluarin fitur ini barusan update"
 
-### [Kimi 2.5](https://kimi.moonshot.cn)
+### Kimi kept showing up as the practical choice
 
-**Sentiment:** 👍 Positive | **Mentions:** 10
+[Kimi 2.5](https://kimi.moonshot.cn) kept getting mentioned as the model people could actually live with day to day. One user ran it for a week in OpenClaw with three agents working in the same group and came away satisfied. That kind of field report carries more weight than a benchmark screenshot.
 
-- Popular single-model choice for OpenClaw
-- [Console available](https://www.kimi.com/code/console)
-- Week-long test: "3 agent gebuk2an di group ngelarin beberapa fitur. So far puas sih."
-- Considering Allegretto upgrade
+The appeal was simple: good enough quality, familiar workflow, and less pricing drama than the premium Western stack.
 
-**Key Quote:**
 > "Ternyata bukan perasaan gw doang, banyak juga yg pake single model Kimi 2.5 di Openclaw 😆"
 
----
+### Claude Code had the usual performance baggage
 
-### [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) was still in the mix, but the tone was more weary than excited. The main complaint was RAM usage. People reported sessions swelling into the 60-90GB range, with daily restarts becoming a habit rather than an exception.
 
-**Sentiment:** 😟 Mixed | **Mentions:** 12
+Auto-compaction came up, multiple CLI sessions made it worse, and the practical workaround was not glamorous: restart hard and keep moving.
 
-- Memory leak issues reported: **60-90GB RAM** usage
-- "Mungkin ada memory leak Mas. Kalau aku memang udah kebiasaan hard restart hampir tiap hari"
-- Auto-compaction feature discussed
+> "Mungkin ada memory leak Mas. Kalau aku memang udah kebiasaan hard restart hampir tiap hari"
 
----
+### OpenClaw stayed useful and expensive
 
-### [Warp Oz](https://www.warp.dev/oz)
+[OpenClaw](https://openclaw.ai) got plenty of attention because it supports a lot of providers and makes multi-agent setups approachable. It also kept getting called expensive. The complaint was not really about one model. It was about context bloat: `MEMORY.md`, `SOUL.md`, and project files all riding along in each request.
 
-**Sentiment:** 🔥 New & Exciting
+That led to a familiar conclusion. If you want the convenience of a rich agent setup, you have to respect the cost of carrying all that context. Several people were already thinking in orchestrator patterns to keep the heavy context where it belongs and route smaller tasks elsewhere.
 
-- Just released agent orchestration feature
-- "warp ngeluarin fitur ini barusan update"
-- Sparking "agent orchestration hype" discussion
+> "Openclaw boros bgt asli"
 
----
+### Excalidraw and Trae were side notes, not the main event
 
-### [OpenClaw](https://openclaw.ai)
+[Excalidraw](https://excalidraw.com) got a quick nod for its improving AI features. [Trae.ai](https://trae.ai) came up mostly as a Cursor alternative, with the usual caveat that losing Claude support is a real trade-off for some people.
 
-**Sentiment:** 😅 Mixed | **Mentions:** 20
+## The Bigger Themes
 
-- Multi-provider support praised: "Openclaw udh support kabeh wkwk"
-- Cost concerns: "Openclaw boros bgt asli"
-- [Beelink mini PCs](https://www.bee-link.com) mentioned for self-hosting
-- Ban risk discussed for unofficial OAuth usage
+### 1. No-IDE club is no longer niche
 
----
+Augment Intent joined Claude Code and Amp in making terminal-first work feel normal. The interesting part is not any single release. It is the direction of travel.
 
-### [Excalidraw](https://excalidraw.com)
+### 2. Agent orchestration is becoming the next pressure point
 
-**Sentiment:** 🔥 Positive
+Warp Oz helped push that discussion, but the anxiety was broader than one product. People could feel the stack moving from single prompts to systems of prompts.
 
-- AI features improving: "makin seru pakai excalidraw"
-- [Feature updates](https://x.com/excalidraw/status/2021284377506742331)
+### 3. Cost discipline keeps shaping tool choices
 
----
+Amp deep mode, OpenClaw context costs, and the scramble for free tiers all pointed to the same reality: pricing now shapes architecture. People are not just asking what works best. They are asking what still works when repeated every day.
 
-### [Trae.ai](https://trae.ai)
+## Mood Check
 
-**Sentiment:** 🤔 Discussed
+What got people excited:
 
-- Asked as Cursor alternative
-- Limitation: no Claude support
-- "kalau mau ngorbanin gak ada Claude bisa jadi"
+- Augment Intent joining the no-IDE movement
+- Warp Oz shipping orchestration
+- Amp's next version getting closer
+- Raspberry Pi showing up as an AI box worth watching: "pi ini semakin dilirik makin menarik 🤣"
 
----
+What made people uneasy:
 
-## 🎯 Key Discussions
+- Job anxiety in the middle of all this change
+- Claude Code eating absurd amounts of memory
+- OpenClaw cost creep
+- Ban risk around unofficial OAuth setups
 
-### 1. No-IDE Club Rising
-Terminal-based coding gaining traction. Augment released "Intent", joining Claude Code and Amp in the no-IDE space.
-- Augment Code released Intent feature
-- Claude Code and Amp already popular for terminal workflows
-- Some still prefer Cursor/Windsurf for IDE features
-
-### 2. Agent Orchestration Hype
-Is this the next big thing after prompt engineering? Fear of being left behind.
-- Warp Oz released agent orchestration
-- Rapid pace causing anxiety
-- Question: "Yg masih belajar prompt engineering bakal ketinggalan kereta?"
-
-### 3. Claude Code Memory Issues
-Users reporting excessive RAM consumption (60-90GB), potential memory leaks.
-- Multiple CLI sessions compound the issue
-- Auto-compaction may contribute
-- Daily restart recommended as workaround
-
-### 4. Cost vs Value Trade-offs
-Balancing AI tool costs with productivity gains. Free tiers getting scarce.
-- Amp deep mode praised for cost efficiency
-- OpenClaw costs add up quickly
-- Free tier strategies discussed
-
----
-
-## 📊 Sentiment Snapshot
-
-### 🔥 Excitement
-- **Augment Intent release** — no-IDE movement growing
-- **Warp Oz** agent orchestration
-- **Amp Code** next version anticipation
-- Raspberry Pi for AI getting attention: "pi ini semakin dilirik makin menarik 🤣"
-
-### 😟 Concerns
-- **Job fears:** "Fix bakal kena layoff ini kyknya 😅" (on rapid AI pace)
-- **Claude Code RAM:** 60-90GB memory leaks
-- **OpenClaw costs:** "boros bgt asli"
-- **Ban risks:** OAuth usage concerns
-
-### 😂 Humor of the Week
+And the best jokes still came from the token economy:
 
 > "flexingnya skrg: lambo lu warna apa bos? ❌ token Opus lu unlimited gak bos? ✅"
 
@@ -182,33 +129,17 @@ Balancing AI tool costs with productivity gains. Free tiers getting scarce.
 
 > "kalau pakai bot beneran tdk bisa dibayangkan chaos grup ini 🤣"
 
-> "hbs ini pada bikin claw sendiri 😅"
+## One Link That Landed Hard
 
-### 🤔 Open Questions
-- "agent swarm nya sendiri sering kepakai gak?"
-- "worth gak sih ngorbanin [Claude] ini?" (re: Trae.ai)
+[Nolan Lawson's "We Mourn Our Craft"](https://nolanlawson.com/2026/02/07/we-mourn-our-craft/) got shared as a morning reflection. That one hit a nerve. There were several sad reactions because it named the thing many developers are feeling right now: excitement, grief, curiosity, and exhaustion all mixed together.
 
----
+## What I'd Keep an Eye On
 
-## 📰 Articles Worth Reading
-
-### [We Mourn Our Craft](https://nolanlawson.com/2026/02/07/we-mourn-our-craft/) by Nolan Lawson
-
-Shared as "Renungan pagi ini" — a reflection on AI's impact on software craftsmanship. Multiple 😢 reactions from the group.
-
----
-
-## ✅ Action Items / Recommendations
-
-1. **[Try Warp Oz](https://www.warp.dev/oz)** for agent orchestration
-
-2. **[Watch Augment Intent](https://augmentcode.com)** — no-IDE trend growing
-
-3. **[Monitor Amp Code waitlist](https://ampcode.com/news/amp-free-is-full-for-now)** — free tier currently full
-
-4. **[Consider Kimi 2.5](https://kimi.moonshot.cn)** as budget-friendly option for OpenClaw
-
-5. **[Read "We Mourn Our Craft"](https://nolanlawson.com/2026/02/07/we-mourn-our-craft/)** — thoughtful reflection on AI era
+1. Try [Warp Oz](https://www.warp.dev/oz) if you want to see where agent orchestration inside the terminal is heading.
+2. Watch [Augment Intent](https://augmentcode.com) because the no-IDE category is moving fast.
+3. Keep an eye on the [Amp Code waitlist](https://ampcode.com/news/amp-free-is-full-for-now) if you were relying on the free path.
+4. Consider [Kimi 2.5](https://kimi.moonshot.cn) if you want something cheaper for OpenClaw experiments.
+5. Read ["We Mourn Our Craft"](https://nolanlawson.com/2026/02/07/we-mourn-our-craft/) if you want the emotional side of this moment put into words.
 
 ---
 

--- a/app/routes/blog.ai-tools-swe-growth-mar-16-mar-22-2026.mdx
+++ b/app/routes/blog.ai-tools-swe-growth-mar-16-mar-22-2026.mdx
@@ -32,137 +32,124 @@ export const meta = () => attributes.meta;
 
 # Hemat Token Itu Seni, Mudik Bawa Starlink Itu Dedikasi
 
-Minggu ini grup kita agak unik — campuran antara diskusi teknis yang serius dan vibes lebaran yang hangat. Di satu sisi, ada perdebatan sengit soal strategi hemat token Opus. Di sisi lain, ada yang mudik bawa Mac mini dan Starlink. Yep, that's us. 😅
+Minggu ini grup campur aduk dengan cara yang khas. Satu sisi isinya debat serius soal cara pakai Opus biar tidak jebol di hari pertama. Sisi lain, orang-orang lagi persiapan mudik sambil bawa Mac mini, UPS, sampai Starlink. Sangat AI Tools SWE GROWTH.
 
-## 🎯 Strategi Hemat Opus: Plan Sonnet, Review Opus
+## Strategi Hemat Opus di Paket $20
 
-Topik paling ramai minggu ini dimulai dari pertanyaan polos Mas Fajar: *"yg pakai Claude code opus itu setting nya gmna biar oke ya. soalnya takut pakai opus limit hariannya langsung ludes."*
+Topik paling ramai berawal dari pertanyaan polos Mas Fajar: *"yg pakai Claude code opus itu setting nya gmna biar oke ya. soalnya takut pakai opus limit hariannya langsung ludes."*
 
-Mas Michael langsung menjawab dengan realita pahit: *"kalau paket $20 mau settingan gmna opus itu udah mahal mas."* Dan dia menambahkan, *"cocok2 aja kok tapi kalau mau fully opus gak usah ngimpi mas kalau $20 🤣."*
+Mas Michael langsung kasih realita pahit: *"kalau paket $20 mau settingan gmna opus itu udah mahal mas."* Lalu dia tambah lagi, *"cocok2 aja kok tapi kalau mau fully opus gak usah ngimpi mas kalau $20 🤣."*
 
-Tapi justru dari sini muncul strategi yang menarik. Mas Zahid membagikan workflow-nya: *"Pakai buat review plan aja. Jadi cuman 1 shot."* Singkatnya — plan pakai Sonnet, Opus cuma untuk review. Mas Almas bahkan menambahkan referensi tools-nya: *"Saya biasanya pakai opus dan superpower skill untuk write plan. Eksekusi tasksnya pakai sonnet atau haiku tergantung kebutuhan."* Pakai [Superpowers](https://github.com/obra/superpowers) untuk structuring plan.
+Dari situ muncul pola yang lebih masuk akal. Mas Zahid bilang, *"Pakai buat review plan aja. Jadi cuman 1 shot."* Mas Almas punya workflow yang mirip: *"Saya biasanya pakai opus dan superpower skill untuk write plan. Eksekusi tasksnya pakai sonnet atau haiku tergantung kebutuhan."* [Superpowers](https://github.com/obra/superpowers) dipakai untuk bantu ngerapikan plan, lalu model yang lebih murah dipakai buat jalanin pekerjaannya.
 
-Mas Otniel punya pendekatan lain: *"pake buat bikin plan, orchestrate agent yg lebih tidak pintar. gw pake opencode jadi bisa multi-agent orchestrator."* Jadi Opus sebagai "otak" yang mendelegasikan ke model yang lebih murah.
+Mas Otniel mengambil arah lain: *"pake buat bikin plan, orchestrate agent yg lebih tidak pintar. gw pake opencode jadi bisa multi-agent orchestrator."* Jadi Opus diperlakukan seperti otak utama, bukan kuli harian.
 
-Saya sendiri menambahkan realita Pro plan: *"Judulnya aja 'Pro', padahal kalau dipake buat Opus udah berasa 'Lite'. Buat 2-3 prompt berat udah habis limit kuota 5 jam. 😅"* Dan joke yang cukup merangkum minggu ini: *"Mungkin 'Pro' di situ maksudnya udah 'penggunanya sudah PROfessional dalam berhemat.'"* 😆
+Saya juga ikut nimbrung dari sisi pengguna Pro plan: *"Judulnya aja 'Pro', padahal kalau dipake buat Opus udah berasa 'Lite'. Buat 2-3 prompt berat udah habis limit kuota 5 jam. 😅"* Minggu ini memang rasanya begitu. Kalau mau tetap pakai Opus, yang perlu dioptimalkan bukan modelnya saja, tapi kapan dia dipanggil.
 
-Oh, dan kabar baiknya — Mas Luthfi share bahwa bulan Maret ada [promo 2x limit](https://support.claude.com/en/articles/14063676-claude-march-2026-usage-promotion) di Claude. Mas Riza Rohman bahkan sudah upgrade ke Max, walau sempat bingung karena *"udah bayar tapi masih pro ya"* — ternyata perlu logout dulu. 😅
+Kabar baiknya, Mas Luthfi menemukan [promo 2x limit](https://support.claude.com/en/articles/14063676-claude-march-2026-usage-promotion) untuk bulan Maret. Mas Riza Rohman bahkan langsung upgrade ke Max, walau sempat bingung karena *"udah bayar tapi masih pro ya"* dan ternyata perlu logout dulu.
 
-Pertanyaannya bukan lagi "pakai model apa" tapi "kombinasi model apa yang paling cost-effective." Opus jadi luxury item, bukan daily driver.
+## Opus Di-nerf, atau Toolchain Kita yang Sudah Kegemukan?
 
-## 🔥 Opus Di-nerf? Atau Kita Yang Terlalu Banyak Harness?
+Mas Agung mengeluhkan reasoning Opus yang terasa turun: *"bukan mas, di nerf nya itu reasoning nya. kerasa banget reasoning nya di nerf wkwk semenjak rilis yang fast."* Efeknya terasa jelas di pekerjaan sehari-hari. *"yang kemarin bisa di tinggal tidur, sekarang kudu di guide lagi biar gak halu wkwk."*
 
-Mas Agung mengeluhkan sesuatu yang beberapa orang juga rasakan: *"bukan mas, di nerf nya itu reasoning nya. kerasa banget reasoning nya di nerf wkwk semenjak rilis yang fast."* Dan ditambah: *"yang kemarin bisa di tinggal tidur, sekarang kudu di guide lagi biar gak halu wkwk."*
+Saya membalas dengan [thread dari @systematicls](https://x.com/systematicls/status/2028814227004395561) yang intinya begini: kalau kita kebanyakan menempelkan harness manual seperti MCP, RAG, vectordb, atau syscall, model yang lebih baru kadang justru jadi kelihatan lebih buruk karena dibebani terlalu banyak hal yang sebenarnya sudah bisa ia lakukan sendiri.
 
-Tapi saya punya perspektif yang berbeda di sini. Saya share [thread dari @systematicls](https://x.com/systematicls/status/2028814227004395561) yang intinya: kalau kamu setup terlalu banyak harnessing manual (MCP, RAG, vectordb, syscall, dsb), ketika model-nya improved, beberapa harnessing itu justru jadi noise — karena model-nya sudah bisa pakai native solutions.
+Mas Agung menanggapi dengan jujur: *"meksens, keknya harus tak audit tools yang obsolete."* Buat saya itu inti diskusinya. Bisa saja modelnya berubah. Bisa juga stack kita yang sudah terlalu berat.
 
-Mas Agung merespons jujur: *"meksens, keknya harus tak audit tools yang obsolete."* Dan itu insight yang penting — kadang yang bikin "lemot" bukan model-nya yang di-nerf, tapi kita yang over-tooling.
+Di saat yang sama, Claude sendiri memang sedang tidak baik-baik saja. [status.claude.com](https://status.claude.com/) beberapa kali menunjukkan elevated errors. Mas Arif kena langsung: *"claude code barusan bgt dapet error code 529."* Mas El Muhammad menduga ini efek promo 2x limit. Mas Iqbal menimpali dengan bercanda: *"Apakah krn di ship code nya dg claude code sendiri xD."*
 
-Sementara itu, Claude sendiri lagi tidak baik-baik saja — [status.claude.com](https://status.claude.com/) menunjukkan elevated errors beberapa hari terakhir. Mas Arif bahkan kena langsung: *"claude code barusan bgt dapet error code 529."* Mas El Muhammad menduga ini *"efek 2x token limit"* — terlalu banyak yang pakai promo. Dan Mas Iqbal bercanda: *"Apakah krn di ship code nya dg claude code sendiri xD."*
+## Windsurf Naik Harga, dan Itu Tidak Mengejutkan Lagi
 
-Apakah Opus benar-benar di-nerf, atau kita yang perlu re-evaluate toolchain kita? Mungkin jawabannya: sedikit keduanya.
+Mas Dedy P membawa berita yang memang sudah lama dicium orang: [Windsurf mengumumkan pricing baru berbasis quota](https://www.reddit.com/r/windsurf/comments/1rxii0o/introducing_our_new_windsurf_pricing_plans/). Mas Fajar langsung merespons, *"udah mulai berasa mahal ai nya."*
 
-## 💸 Windsurf Naik Harga, AI Makin Mahal
+Mas Michael tidak kelihatan kaget. Katanya, *"seperti yang sudah banyak di prediksi di X tinggal tunggu waktu memang."* Analisis lanjutannya juga tajam: *"gak bakal sustain lagi kalau request AI dikasih loss tanpa hitung token yg keluar... tetap bisa pake AI tapi untuk yg premium suka gak suka memang bakal dipaksa lebih dari $20."*
 
-Mas Dedy P membawa berita yang sudah lama diprediksi: [Windsurf mengumumkan pricing baru berbasis quota](https://www.reddit.com/r/windsurf/comments/1rxii0o/introducing_our_new_windsurf_pricing_plans/). Mas Fajar langsung merespons: *"udah mulai berasa mahal ai nya."*
+Mas Kevin mengingatkan sesuatu yang sering kelewat: *"harga energi juga mahal apalagi green energy."* Itu poin yang penting. Model mahal bukan cuma soal hype atau margin. Ada biaya infrastruktur yang memang besar.
 
-Mas Michael, yang memang sering memantau tren pricing, tidak kaget: *"seperti yang sudah banyak di prediksi di X tinggal tunggu waktu memang."* Dan analisisnya tajam: *"gak bakal sustain lagi kalau request AI dikasih loss tanpa hitung token yg keluar... tetap bisa pake AI tapi untuk yg premium suka gak suka memang bakal dipaksa lebih dari $20."*
+Mas Zahid lalu menyimpulkan dari sisi operator: *"Jadi pada akhirnya yg punya infra gede dan income subsidi yg menang. 😅"* Wrapper seperti OpenCode, Amp, dan teman-temannya bakal ikut kena imbas karena mereka berdiri di atas biaya model yang juga ikut bergerak.
 
-Mas Kevin menambahkan faktor yang sering dilupakan: *"harga energi juga mahal apalagi green energy."* Benar — infrastruktur AI bukan cuma soal GPU, tapi juga listrik.
+## Claude Code dan OpenCode Memang Soal Cocok-cocokan
 
-Mas Zahid punya kesimpulan yang pragmatis: *"Jadi pada akhirnya yg punya infra gede dan income subsidi yg menang. 😅"* Dan menyebut bahwa wrapper seperti OpenCode, Amp, dan AI agent wrapper lainnya yang paling terdampak.
+Mas Aidityas sempat bilang, *"setelah 1 jam menggunakan claude code, sepertinya balik lagi ke opencode :)"* Saya justru kebalikannya: *"Emang cocok-cocokan sih. Saya malah sebaliknya, setelah 1 jam menggunakan OpenCode, balik lagi ke Claude Code. 🤣"*
 
-Era $20 unlimited AI sudah berakhir. Yang tersisa adalah seni berhemat — dan itu skill yang ternyata lebih penting dari prompting.
+Mas Galih sedang menikmati Claude Code Desktop yang makin enak karena bisa kasih context lewat selection mode. Mas Aidityas juga nemu alternatif lain yang dia suka: *"Kalau ini saya senengnya pakai agentation.dev."*
 
-## 🔄 Claude Code vs OpenCode: Cocok-cocokan
+Tips session management ikut muncul di bagian ini. Mas Zahid mengingatkan soal `/resume`. Saya menambahkan `claude --continue` untuk langsung lanjut sesi terakhir, plus trik memakai `CLAUDE.md` di folder yang lebih sempit supaya konteks per fitur tetap rapi.
 
-Minggu ini ada momen lucu. Mas Aidityas: *"setelah 1 jam menggunakan claude code, sepertinya balik lagi ke opencode :)"* Dan saya menjawab: *"Emang cocok-cocokan sih. Saya malah sebaliknya, setelah 1 jam menggunakan OpenCode, balik lagi ke Claude Code. 🤣"*
+Tool terbaik minggu ini bukan yang paling viral di X. Tool terbaik ya yang paling pas dengan cara kerja sendiri.
 
-Mas Galih meanwhile sedang menikmati Claude Code Desktop yang ternyata sudah makin canggih — bisa kasih context pakai selection mode. Mas Aidityas juga menemukan alternatif menarik: *"Kalau ini saya senengnya pakai agentation.dev."*
+## Quick Hits
 
-Tips session management Claude Code juga muncul minggu ini — Mas Zahid mengingatkan tentang `/resume`, dan saya menambahkan tentang `claude --continue` untuk langsung lanjut sesi terakhir, plus trick CLAUDE.md di nested folder untuk konteks per-fitur.
+- Firebase Studio dimatikan. Google resmi migrasi ke AI Studio dan Antigravity. Mas Iqbal memprediksi *"antigravity yg mati wkwk"*, sementara Mas Tegar bilang dia lebih suka Antigravity tapi masih cari cara menyambungkannya ke HP buat ngoding sambil rebahan. Mas Iqbal menyarankan [Remoat](https://github.com/optimistengineer/remoat).
+- OpenAI mengakuisisi Astral dan fokusnya ke Python serta UV. Mas Michael merangkum dengan singkat: *"anthropic ambil Bun, OpenAI fokus ke python(UV) 🔥."*
+- Cursor berpotensi kena masalah hukum karena urusan trademark Composer 2. Mas Faris berspekulasi tiap kali provider ngeluarin model baru, selalu ada kubu kompetitor yang sibuk cari celah hukum.
+- [Cerebras](https://chat.cerebras.ai/) bikin Mas Agung kagum karena *"tidak fomo tapi diem diem tembus 16k token /sec."* Mas Michael mengingatkan premium-nya sekitar $50 per bulan.
+- Tombol cancel Kimi ternyata susah dicari. Mas Restu frustrasi, lalu Mas Desilino memberi tips buat membalas email failed charge agar charging-nya dihentikan.
+- [OpenAgentsControl](https://github.com/darrenhinde/OpenAgentsControl) dibagikan Mas Zahid buat manajemen konteks codebase. Mas Salma langsung tertarik.
+- MiniMax lagi diskon. Mas Michael bilang cukup bikin artikel di X, nanti bisa dapat credits.
+- Mas Abdul Rahman membagikan info hackathon Trae.ai di Bali tanggal 28 Maret.
 
-Tool terbaik adalah tool yang cocok sama workflow kamu. Bukan yang paling trending di X.
+## Mudik Edition: Home Server, Starlink, dan Niat Besar
 
-## ⚡ Quick Hits
+Bagian paling wholesome minggu ini datang dari obrolan mudik. Saya bawa Mac mini, game console, dan Starlink ke rumah ortu supaya tetap bisa ngoding dan main game bareng anak-anak. Internet rumah ortu cuma 20 Mbps, jadi perbedaan dengan Starlink terasa sekali.
 
-- **Firebase Studio dimatikan** — Google resmi migrasi ke AI Studio & Antigravity. Mas Iqbal prediksi *"antigravity yg mati wkwk"*, Mas Tegar lebih suka Antigravity tapi *"masih nyari cara gimana bisa nyambungin antigravity ke hp biar bisa ngoding sambil rebahan wkwk."* Mas Iqbal menyarankan [Remoat](https://github.com/optimistengineer/remoat).
+Mas El Muhammad naik level lebih tinggi. Sebelum mudik dia sudah menyiapkan home server dengan UPS, dual network, dan open rack. Katanya, *"udah di test sebelum berangkat dengan di cabut listriknya dan dimatikan meteran listriknya dia bisa booting sendiri."* Tips praktisnya jelas: aktifkan "Start up automatically after power failure" dan auto login tanpa password di macOS.
 
-- **OpenAI akuisisi Astral** — fokus ke Python/UV, sementara Anthropic ambil Bun. Mas Michael: *"anthropic ambil Bun, OpenAI fokus ke python(UV) 🔥."* Persaingan ekosistem makin jelas.
+Mas Salma masih di tahap membangun mimpi: *"Pgn punya homeserver gini, Alhamdulillah PSU nya dah kebeli 🤣."* Mas Ivan juga mulai pelan-pelan: *"Saya malah dah punya kabel cat 6 nya 100m. Tinggal nyicil yg lainnya 😂."*
 
-- **Cursor berpotensi kena masalah hukum** — Mas Michael share link tentang Composer 2 yang mungkin melanggar trademark. Mas Faris: *"keknya tiap kali provider ngeluarin model baru, ada employee masing-masing kompetitor buat nyari celah nuntut secara hukum."*
+Self-hosting sekarang tidak terasa seperti hobi pinggiran lagi. Buat sebagian orang, ini mulai terasa seperti investasi infrastruktur pribadi.
 
-- **Cerebras** — Mas Agung menemukan [chat.cerebras.ai](https://chat.cerebras.ai/) dan kagum: *"tidak fomo tapi diem diem tembus 16k token /sec."* Mas Michael mengingatkan: itu *"sebulan $50an"* untuk premium.
+## Artikel dan Link Menarik
 
-- **Kimi Cancel Button tersembunyi** — Mas Restu frustasi: *"aku mencari button 'Cancel Plan' tidak ditemukan 😅."* Mas Desilino kasih tips: *"Di reply aja mas email failed to charge nya, minta di stop charging nya."* Mas Faris bahkan compare: *"Masih terbaik Z.ai ya. Bahkan bisa refund padahal subscription-nya lagi ongoing."*
+- [Thread @systematicls tentang over-harnessing AI agents](https://x.com/systematicls/status/2028814227004395561) - Frontier companies akan terus menyerap solusi eksternal ke produk mereka.
+- [Claude March 2026 Usage Promotion](https://support.claude.com/en/articles/14063676-claude-march-2026-usage-promotion) - Promo 2x limit untuk bulan Maret.
+- [Windsurf New Pricing Plans](https://www.reddit.com/r/windsurf/comments/1rxii0o/introducing_our_new_windsurf_pricing_plans/) - Pricing berbasis quota.
+- [OpenCode Queue Feature](https://x.com/0xSero/status/2034243822566187014) - Fitur antrian baru.
+- [OpenAI to Acquire Astral](https://openai.com/index/openai-to-acquire-astral/) - Fokus ke Python tooling.
+- [Firebase Studio Migration](https://firebase.google.com/docs/studio/migrating-project) - Pindah ke AI Studio dan Antigravity.
+- [pi-autoresearch](https://github.com/davebcn87/pi-autoresearch) - Tool auto-research.
+- [OpenAgentsControl](https://github.com/darrenhinde/OpenAgentsControl) - Context manager untuk codebase.
+- [LazyGravity](https://github.com/tokyoweb3/LazyGravity) - Alternatif tool terkait.
 
-- **OpenAgentsControl** — Mas Zahid share [tool ini](https://github.com/darrenhinde/OpenAgentsControl) untuk manajemen konteks codebase. Mas Salma tertarik: *"Wah kriterianya sesuai mas, nanti sya coba."*
+## Yang Perlu Dicoba Minggu Ini
 
-- **MiniMax diskon** — Mas Michael share cara dapat diskon: buat artikel di X tentang MiniMax, nanti dikasih credits.
+1. Pakai [Superpowers skill](https://github.com/obra/superpowers) kalau mau menjadikan Opus penulis plan dan model lain sebagai eksekutor.
+2. Audit toolchain sendiri. Bisa jadi ada MCP atau harness yang sebenarnya sudah tidak perlu.
+3. Coba [OpenAgentsControl](https://github.com/darrenhinde/OpenAgentsControl) kalau konteks codebase mulai terasa boros.
+4. Kalau punya Mac mini untuk self-hosting, pastikan auto-restart setelah listrik padam sudah aktif.
+5. Claim [promo Claude 2x limit](https://support.claude.com/en/articles/14063676-claude-march-2026-usage-promotion) sebelum bulan Maret habis.
 
-- **Trae.ai Hackathon di Bali** — Mas Abdul Rahman share info hackathon tanggal 28 Maret. Yang di Bali, merapat!
+## Yang Bikin Diskusi Hidup Minggu Ini
 
-## 🏠 Mudik Edition: Home Server & Starlink
-
-Momen paling wholesome minggu ini: sharing setup mudik. Saya bela-belain bawa Mac mini + game console + Starlink ke rumah ortu biar tetap bisa ngoding dan main game sama anak-anak. Internet rumah ortu cuma 20 Mbps — dibanding Starlink, bagaikan bumi dan langit. 😅
-
-Mas El Muhammad level-nya lebih tinggi lagi — dia setup home server dengan UPS, dual network, dan open rack sebelum mudik. *"udah di test sebelum berangkat dengan di cabut listriknya dan dimatikan meteran listriknya dia bisa booting sendiri."* Tips penting: enable "Start up automatically after power failure" + auto login tanpa password di macOS.
-
-Mas Salma yang masih merintis bermimpi: *"Pgn punya homeserver gini, Alhamdulillah PSU nya dah kebeli 🤣."* Mas Ivan sudah mulai: *"Saya malah dah punya kabel cat 6 nya 100m. Tinggal nyicil yg lainnya 😂."*
-
-Self-hosting di era AI bukan lagi hobi niche — ini investasi infrastruktur personal yang makin masuk akal.
-
-## 📰 Artikel & Link Menarik
-
-- [Thread @systematicls tentang over-harnessing AI agents](https://x.com/systematicls/status/2028814227004395561) — Frontier companies akan selalu incorporate external solutions ke produk mereka
-- [Claude March 2026 Usage Promotion](https://support.claude.com/en/articles/14063676-claude-march-2026-usage-promotion) — 2x limit bulan Maret
-- [Windsurf New Pricing Plans](https://www.reddit.com/r/windsurf/comments/1rxii0o/introducing_our_new_windsurf_pricing_plans/) — Quota-based pricing
-- [OpenCode Queue Feature](https://x.com/0xSero/status/2034243822566187014) — Fitur antrian baru
-- [OpenAI to Acquire Astral](https://openai.com/index/openai-to-acquire-astral/) — Python tooling focus
-- [Firebase Studio Migration](https://firebase.google.com/docs/studio/migrating-project) — Pindah ke AI Studio & Antigravity
-- [pi-autoresearch](https://github.com/davebcn87/pi-autoresearch) — Auto-research tool
-- [OpenAgentsControl](https://github.com/darrenhinde/OpenAgentsControl) — Codebase context manager
-- [LazyGravity](https://github.com/tokyoweb3/LazyGravity) — Alternative tool
-
-## ✅ Yang Perlu Dicoba Minggu Ini
-
-1. **[Superpowers skill](https://github.com/obra/superpowers)** untuk plan-with-Opus workflow — hemat token, hasil tetap bagus
-2. **Audit toolchain-mu** — cek apakah ada MCP/harness yang sudah obsolete karena model sudah improved
-3. **[OpenAgentsControl](https://github.com/darrenhinde/OpenAgentsControl)** untuk manajemen konteks codebase tanpa boros token
-4. **Enable auto-restart di Mac mini** — kalau kamu self-hosting, pastikan mesin bisa recovery dari power failure
-5. **Claim [Claude March 2x promo](https://support.claude.com/en/articles/14063676-claude-march-2026-usage-promotion)** — bulan ini ada 2x usage limit, jangan sampai kelewat
-
-## 👥 Kontributor Minggu Ini
-
-- **Mas Michael** — News curator utama grup, selalu up-to-date dengan tren X, analisis pricing yang tajam
-- **Mas Zahid** — OpenAgentsControl, Ali code workflow, strategi Opus 1-shot review
-- **Mas Fajar** — Pertanyaan yang memicu diskusi terbaik minggu ini tentang Opus strategy
-- **Mas Agung** — Insight jujur soal Opus nerfing, Cerebras discovery, Claude Code offloading
-- **Mas Faris** — Analisis bounty hunting kompetitor, perbandingan refund policy
-- **Mas Iqbal** — Remoat recommendation, Antigravity predictions, engagement yang selalu seru
-- **Mas Otniel** — OpenCode multi-agent orchestrator workflow
-- **Mas Almas** — Superpowers skill recommendation untuk plan writing
-- **Mas El Muhammad** — Home server setup masterclass dengan UPS dan auto-boot
-- **Mas Tegar** — Happy Coder experience, Antigravity review, LazyGravity discovery
-- **Mas Galih** — Claude Code Desktop showcase
-- **Mas Aidityas** — Honest take: Claude Code → OpenCode → Claude Code
-- **Mas Dedy P** — Windsurf pricing alert pertama
-- **Mas Luthfi** — Claude March promo discovery
-- **Mas Riza Rohman** — Claude Max upgrade pioneer
-- **Mas Restu** — Kimi cancel button exposé
-- **Mas Desilino** — Kimi workaround tips, Kilo pass recommendation
-- **Mas Kevin** — Energy cost perspective
-- **Mas Salma** — Home server aspirations, Starlink questions, OpenAgentsControl interest
-- **Mas Joko** — Workflow confirmation
-- **Mbak Eka** — "ada ribuan cara untuk gagal" — the most relatable reaction ever
-- **Mas Deryalfi** — Kimi discount still available intel
-- **Mas Abdul Rahman** — Trae.ai Hackathon Bali info
-- **Mas Ivan** — Cat 6 cable ready, home server journey beginning
-- **Mas Arif** — 529 error firsthand report
-- **Mas Latief** — Engagement and humor
-- **Mas Yazid** — AGY artifact mechanism question
+- Mas Michael: kurator berita utama grup, tajam di analisis pricing, dan selalu cepat menangkap arah tren.
+- Mas Zahid: bawa OpenAgentsControl, workflow Ali code, dan strategi Opus 1-shot review.
+- Mas Fajar: pertanyaan awalnya memicu diskusi terbaik minggu ini soal cara pakai Opus dengan waras.
+- Mas Agung: jujur soal rasa Opus yang berubah, plus temuan Cerebras dan workflow Claude Code.
+- Mas Faris: kuat di analisis kompetitor dan soal refund policy.
+- Mas Iqbal: selalu bikin obrolan teknis tetap hidup, dari Remoat sampai prediksi Antigravity.
+- Mas Otniel: berbagi pola multi-agent orchestrator di OpenCode.
+- Mas Almas: merekomendasikan Superpowers untuk plan writing.
+- Mas El Muhammad: ngasih masterclass home server dengan UPS dan auto-boot.
+- Mas Tegar: cerita Happy Coder, review Antigravity, dan nemu LazyGravity.
+- Mas Galih: menunjukkan sisi praktis Claude Code Desktop.
+- Mas Aidityas: jujur soal pindah bolak-balik antara Claude Code dan OpenCode.
+- Mas Dedy P: orang pertama yang mengangkat pricing baru Windsurf.
+- Mas Luthfi: penemu promo Claude bulan Maret.
+- Mas Riza Rohman: pionir upgrade ke Claude Max.
+- Mas Restu: korban tombol cancel Kimi yang terlalu tersembunyi.
+- Mas Desilino: kasih jalan keluar buat urusan Kimi dan charging.
+- Mas Kevin: mengingatkan biaya energi di balik semua hype ini.
+- Mas Salma: bertanya soal homeserver dan tertarik ke OpenAgentsControl.
+- Mas Joko: ikut mengonfirmasi workflow yang dibahas.
+- Mbak Eka: punya reaksi paling relatable minggu ini.
+- Mas Deryalfi: kasih kabar soal diskon Kimi yang masih ada.
+- Mas Abdul Rahman: membagikan info hackathon Trae.ai Bali.
+- Mas Ivan: sudah mulai cicil home server dengan kabel Cat 6 sepanjang 100 meter.
+- Mas Arif: laporan langsung soal error 529.
+- Mas Latief: menjaga ritme obrolan tetap seru.
+- Mas Yazid: bertanya soal mekanisme AGY artifact.
 
 ---
 
 *Ditulis dari dalam grup, bukan dari luar.*
-*Zain Fathoni, dengan bantuan [Bro Pro 🚔](https://ark.zainf.dev/#prowl), [Kang Re 📼](https://ark.zainf.dev/#rewind), dan [Lek Jack 🛠️](https://ark.zainf.dev/#wheeljack) — 22 Maret 2026*
+*Zain Fathoni, dengan bantuan [Bro Pro 🚔](https://ark.zainf.dev/#prowl), [Kang Re 📼](https://ark.zainf.dev/#rewind), dan [Lek Jack 🛠️](https://ark.zainf.dev/#wheeljack), 22 Maret 2026*

--- a/app/routes/blog.ai-tools-swe-growth-mar-2-mar-8-2026.mdx
+++ b/app/routes/blog.ai-tools-swe-growth-mar-2-mar-8-2026.mdx
@@ -1,13 +1,13 @@
 ---
 meta:
-  - title: "Codex Naik Tahta, Kere Hore Naik Kelas, dan Semua Orang Jadi Multi-Tool — AI Tools Digest #6"
+  - title: "Codex Naik Tahta, Kere Hore Naik Kelas, dan Semua Orang Jadi Multi-Tool: AI Tools Digest #6"
   - name: description
     content: "Minggu ini Codex menang head-to-head lawan Opus, Droid Mission Control bikin geleng-geleng, dan batas 'kere hore' resmi naik ke $40. Rangkuman dari grup AI Tools SWE GROWTH, 2-8 Mar 2026."
   - author: Zain Fathoni
   - date: "2026-03-08"
   - lang: id
   - property: og:title
-    content: "Codex Naik Tahta, Kere Hore Naik Kelas, dan Semua Orang Jadi Multi-Tool — AI Tools Digest #6"
+    content: "Codex Naik Tahta, Kere Hore Naik Kelas, dan Semua Orang Jadi Multi-Tool: AI Tools Digest #6"
   - property: og:description
     content: "Minggu ini Codex menang head-to-head lawan Opus, Droid Mission Control bikin geleng-geleng, dan batas 'kere hore' naik ke $40. Rangkuman dari grup AI Tools SWE GROWTH, 2-8 Mar 2026."
   - property: og:url
@@ -19,7 +19,7 @@ meta:
   - property: og:image:height
     content: "630"
   - property: og:image:alt
-    content: "Codex Naik Tahta, Kere Hore Naik Kelas, dan Semua Orang Jadi Multi-Tool — AI Tools Digest #6"
+    content: "Codex Naik Tahta, Kere Hore Naik Kelas, dan Semua Orang Jadi Multi-Tool: AI Tools Digest #6"
   - name: twitter:card
     content: summary_large_image
 ---
@@ -32,81 +32,81 @@ export const meta = () => attributes.meta;
 
 # Codex Naik Tahta, Kere Hore Naik Kelas, dan Semua Orang Jadi Multi-Tool
 
-Minggu ini 850 pesan. Dan yang paling menarik bukan satu tool baru — tapi kenyataan bahwa tidak ada yang pakai cuma satu tool lagi. Semua orang sudah punya "combo" masing-masing, kayak pemain fighting game yang hafal movesetnya. 😅
+Minggu ini 850 pesan. Dan yang paling menarik bukan satu tool baru, tapi kenyataan bahwa tidak ada yang pakai cuma satu tool lagi. Semua orang sudah punya "combo" masing-masing, kayak pemain fighting game yang hafal movesetnya. 😅
 
 ---
 
-## ⚔️ Codex vs Opus — Head-to-Head yang Mengejutkan
+## ⚔️ Codex vs Opus: Head-to-Head yang Mengejutkan
 
 Kalau minggu lalu masih soal hype tools baru, minggu ini kita masuk fase yang lebih matang: **benchmark sendiri**. Dan hasilnya mengejutkan beberapa orang.
 
 Mas Oshi bikin head-to-head langsung antara Codex 5.3 High dan Opus 4.6 di [Copilot CLI](https://github.com/features/copilot). Task-nya: explore cara running project [Aspire](https://learn.microsoft.com/en-us/dotnet/aspire/) yang banyak dependency. Hasilnya? *"Codex mulus sukses.. Opus banyak ngedit existing code untuk bikin workaround, dan tetep gak jalan 😂"*
 
-Tapi cerita tidak berhenti di situ. Mas Riza Rohman punya pengalaman sebaliknya: *"masih bingung implementasi Codex 5.3 ini dimana. Buat planning dan casual exploration juga jelek banget. Cuma kasih bullet points."* Jadi bukan soal mana yang lebih bagus secara absolut — tapi soal **di mana masing-masing bersinar**.
+Tapi cerita tidak berhenti di situ. Mas Riza Rohman punya pengalaman sebaliknya: *"masih bingung implementasi Codex 5.3 ini dimana. Buat planning dan casual exploration juga jelek banget. Cuma kasih bullet points."* Jadi bukan soal mana yang lebih bagus secara absolut, tapi soal **di mana masing-masing bersinar**.
 
-Mas Michael merangkum konsensusnya dengan elegan: Opus untuk brainstorming dan planning, Codex untuk execution. Dan dia sendiri sudah menjalankan flow itu — *"so far cukup puas dengan brainstorming dan plan sama Opus"*, lalu eksekusi pakai Codex di [Amp Code](https://ampcode.com) deep mode.
+Mas Michael merangkum konsensusnya dengan elegan: Opus untuk brainstorming dan planning, Codex untuk execution. Dan dia sendiri sudah menjalankan flow itu, *"so far cukup puas dengan brainstorming dan plan sama Opus"*, lalu eksekusi pakai Codex di [Amp Code](https://ampcode.com) deep mode.
 
-Yang paling penting dari diskusi ini: **agent harness matters.** Seperti yang saya bilang di grup, *"Sama-sama Opus, kalau beda harnessing-nya, beda juga hasilnya."* Bukan cuma model yang penting, tapi cara mempekerjakan LLM end-to-end — kapan dipanggil, context-nya apa, kapan cache hit. Ini yang bikin [Amp Code](https://ampcode.com) dan [pi.dev](https://pi.dev) terasa berbeda meskipun pakai model yang sama.
+Yang paling penting dari diskusi ini: **agent harness matters.** Seperti yang saya bilang di grup, *"Sama-sama Opus, kalau beda harnessing-nya, beda juga hasilnya."* Bukan cuma model yang penting, tapi cara mempekerjakan LLM end-to-end, kapan dipanggil, context-nya apa, kapan cache hit. Ini yang bikin [Amp Code](https://ampcode.com) dan [pi.dev](https://pi.dev) terasa berbeda meskipun pakai model yang sama.
 
-Pertanyaan yang lebih menarik: kalau Codex sudah bisa execute dengan baik, apakah kita masih butuh Opus untuk semuanya? Atau kita sudah masuk era **model specialization** — Opus mikir, Codex ngerjain?
+Pertanyaan yang lebih menarik: kalau Codex sudah bisa execute dengan baik, apakah kita masih butuh Opus untuk semuanya? Atau kita sudah masuk era **model specialization**, Opus mikir, Codex ngerjain?
 
 ---
 
-## 🔥 Multi-Tool Workflows — Masa Depan yang Sudah Terjadi
+## 🔥 Multi-Tool Workflows: Masa Depan yang Sudah Terjadi
 
 Ini tren paling jelas minggu ini: **tidak ada yang pakai satu tool lagi.** Semua orang punya combo, dan tiap combo unik sesuai kebutuhan dan budget.
 
-Mas Ivan share workflow-nya yang paling mature: Codex sebagai *"hammer"* untuk medium features — *"Codex bagi saya jd 'hammer' buat yg ngerjain 1 feature medium size. Dr awal sampai akhir. Dengan implementation yg solid + prompting untuk kerjakan sampai selesai, code review, test, dan review dengan model lain. Sampai create PR."* Satu feature kelar dalam 45-60 menit, dan di Copilot cuma 1 premium request. Setelah itu refinement pakai [Kimi](https://kimi.com) untuk frontend — *"si Kimi eksekusi nya lebih cepat dan tepat"*. Terakhir, [Gemini CLI](https://blog.google/technology/google-deepmind/gemini-cli-open-source/) untuk browser tests dengan Chrome MCP tool. Tiga model, tiga tugas, satu workflow.
+Mas Ivan share workflow-nya yang paling mature: Codex sebagai *"hammer"* untuk medium features, *"Codex bagi saya jd 'hammer' buat yg ngerjain 1 feature medium size. Dr awal sampai akhir. Dengan implementation yg solid + prompting untuk kerjakan sampai selesai, code review, test, dan review dengan model lain. Sampai create PR."* Satu feature kelar dalam 45-60 menit, dan di Copilot cuma 1 premium request. Setelah itu refinement pakai [Kimi](https://kimi.com) untuk frontend, *"si Kimi eksekusi nya lebih cepat dan tepat"*. Terakhir, [Gemini CLI](https://blog.google/technology/google-deepmind/gemini-cli-open-source/) untuk browser tests dengan Chrome MCP tool. Tiga model, tiga tugas, satu workflow.
 
-Mas Andre Pratama — yang baru kenal [pi.dev](https://pi.dev) minggu lalu — langsung all-in: *"Terima kasih untuk mas mas yang sudah rekomendasi pi.dev — asli mantep banget wkwk."* Workflow-nya: Claude Code + Amp Code Free + pi.dev login pakai Copilot kantor. Bahkan untuk task kecil, pi.dev terasa *"lebih kreatif dan teliti sama hal-hal kecil"*.
+Mas Andre Pratama, yang baru kenal [pi.dev](https://pi.dev) minggu lalu, langsung all-in: *"Terima kasih untuk mas mas yang sudah rekomendasi pi.dev, asli mantep banget wkwk."* Workflow-nya: Claude Code + Amp Code Free + pi.dev login pakai Copilot kantor. Bahkan untuk task kecil, pi.dev terasa *"lebih kreatif dan teliti sama hal-hal kecil"*.
 
-Mas Riza Rohman punya pendekatan paling eklektik: *"mix claude+copilot+codex+kimi+opencode free model 😂"*. Lima tools sekaligus. Dan ini bukan anomali — ini jadi norma baru.
+Mas Riza Rohman punya pendekatan paling eklektik: *"mix claude+copilot+codex+kimi+opencode free model 😂"*. Lima tools sekaligus. Dan ini bukan anomali, ini jadi norma baru.
 
 Saya sendiri sekarang turun ke Claude Max $100 karena kantor sudah kasih Claude Teams. Untuk OpenClaw saja, plus coding kerjaan pakai plan kantor dan gratisan Amp deep mode. *Sejauh ini masih cukup sih, selama pakainya yang deep mode. Karena kalau smart mode cepet habis juga credits gratisannya.* 😅
 
-Artinya apa? Era single-tool loyalty sudah berakhir. Pertanyaannya sekarang bukan "pakai apa" tapi "kombinasi apa yang optimal untuk use case kamu."
+Era single-tool loyalty sudah berakhir. Pertanyaan yang lebih relevan sekarang adalah kombinasi apa yang paling cocok untuk use case kamu.
 
 ---
 
-## 🤖 Droid Mission Control — Orchestrator Baru yang Bikin Geleng
+## 🤖 Droid Mission Control: Orchestrator Baru yang Bikin Geleng
 
 [Droid dari Factory AI](https://factory.ai/news/missions) rilis fitur Mission Control, dan Mas Zahid langsung coba. Reviewnya? *"So far cukup bagus, dia di awal planning dulu, terus misal di tengah-tengah perlu alignment masih bisa, otomatis adjust artifact plan-nya, terus re-organize worker-nya."*
 
 Yang bikin unik: sebelum eksekusi, Droid bikin skill dulu untuk worker-nya. *"Instead of kita taruh docs di plan, untuk framework/libs related dia masukin ke skill,"* kata Mas Zahid. Ini pendekatan yang berbeda dari omo yang agentnya sudah punya spesialisasi bawaan.
 
-Dan yang paling penting buat kaum mendang-mending: **jauh lebih hemat token** dibanding omo. Mas Zahid sendiri bandingkan langsung — omo *"token nya bocor banget 🤣"*, sementara Droid bisa di-tinggal tidur, bangun-bangun kelar semua.
+Dan yang paling penting buat kaum mendang-mending: **jauh lebih hemat token** dibanding omo. Mas Zahid sendiri bandingkan langsung, omo *"token nya bocor banget 🤣"*, sementara Droid bisa di-tinggal tidur, bangun-bangun kelar semua.
 
-Bonus: Droid support BYOK (Bring Your Own Key), jadi tidak harus subscribe service mereka. Meskipun Mas Michael sinis — *"ya namanya jualan mesti subs service mereka 😂"* — ternyata memang bisa pakai key sendiri.
+Bonus: Droid support BYOK (Bring Your Own Key), jadi tidak harus subscribe service mereka. Meskipun Mas Michael sinis, *"ya namanya jualan mesti subs service mereka 😂"*, ternyata memang bisa pakai key sendiri.
 
-Sementara itu, [Oh-My-Pi (omp)](https://github.com/can1357/oh-my-pi) berevolusi jadi Oh-My-OpenAgent — tanda bahwa ekosistem agent CLI makin mature. Pertanyaannya: dalam 3 bulan, berapa banyak orchestrator yang bakal survive?
+Sementara itu, [Oh-My-Pi (omp)](https://github.com/can1357/oh-my-pi) berevolusi jadi Oh-My-OpenAgent, tanda bahwa ekosistem agent CLI makin mature. Pertanyaannya: dalam 3 bulan, berapa banyak orchestrator yang bakal survive?
 
 ---
 
 ## 💸 "Sobat Mentok Kanan" dan Naiknya Batas Kere Hore
 
-Diskusi paling lucu sekaligus paling menyakitkan minggu ini. Dimulai dari Mas Michael yang share tweet soal biaya AI tools di berbagai negara. Mas Iqbal langsung respon: *"Full gaji mas wkwk"* — soal berapa persen gaji yang habis buat subscription.
+Diskusi paling lucu sekaligus paling menyakitkan minggu ini. Dimulai dari Mas Michael yang share tweet soal biaya AI tools di berbagai negara. Mas Iqbal langsung respon: *"Full gaji mas wkwk"*, soal berapa persen gaji yang habis buat subscription.
 
-Lalu muncul istilah baru yang langsung viral di grup: **"sobat mentok kanan"** — orang-orang yang gajinya cukup besar sampai subscription AI berasa kayak jajan. Mas Mukhlis yang memulai: *"New tier unlocked: sobat mentok kanan 😂"*, setelah Mas Michael bilang *"subs max mungkin sama dia sama kek subs pro di kita 😂"*.
+Lalu muncul istilah baru yang langsung viral di grup: **"sobat mentok kanan"**, orang-orang yang gajinya cukup besar sampai subscription AI berasa kayak jajan. Mas Mukhlis yang memulai: *"New tier unlocked: sobat mentok kanan 😂"*, setelah Mas Michael bilang *"subs max mungkin sama dia sama kek subs pro di kita 😂"*.
 
 Mas Zahid memberikan perspektif yang paling real: *"yg jadi masalah bukan mentok kananya, tapi kurs mata uang kita aja yg terlalu mentok bawah. wkwkkw"*
 
-Dan batas "kere hore" resmi naik. Mas Michael menganalisis: *"sepertinya kere hore di waktu skrg sdh naik ke angka under $40 deh. Dulu kan awal-awal kere hore dibawah $20."* Mas Desilino — yang subscribe $39 — kaget: *"Gw pikir gw yg subscribe $39 an udah lepas dari title kere hore 🙈"*
+Dan batas "kere hore" resmi naik. Mas Michael menganalisis: *"sepertinya kere hore di waktu skrg sdh naik ke angka under $40 deh. Dulu kan awal-awal kere hore dibawah $20."* Mas Desilino, yang subscribe $39, kaget: *"Gw pikir gw yg subscribe $39 an udah lepas dari title kere hore 🙈"*
 
 Sementara itu, Singapura kasih [bansos AI premium gratis](https://www.straitstimes.com/singapore/politics/singaporeans-to-receive-free-premium-ai-subscriptions-from-second-half-of-2026) ke warganya. *Bansos-nya Singapore memang beda level* 👍🏼. Mas Desilino pun akhirnya menyerah: *"Dan setelah mempertimbangkan budget dan kebutuhan kerja gw pun balik ke cli aja, uninstall openclaw 🥲"*
 
-Ide bisnis paling kreatif? Mas Ivan: *"Jualan token ketengan pakai kartu untuk Claude Code enak kayaknya 😅. Kayak wifi di rumahan. Jam-jaman 😁"* — dan Mas Michael langsung bilang *"ini market di daerah dijamin laku keras 🔥"*. Saya rasa ini bukan cuma lelucon. Dengan kondisi kurs saat ini, model bisnis kayak gini mungkin memang ada pasarnya.
+Ide bisnis paling kreatif? Mas Ivan: *"Jualan token ketengan pakai kartu untuk Claude Code enak kayaknya 😅. Kayak wifi di rumahan. Jam-jaman 😁"*, dan Mas Michael langsung bilang *"ini market di daerah dijamin laku keras 🔥"*. Saya rasa ini bukan cuma lelucon. Dengan kondisi kurs saat ini, model bisnis kayak gini mungkin memang ada pasarnya.
 
 ---
 
 ## 🛡️ Claude Down, Akun Kena Suspend, dan OpenClaw Manggil Miner
 
-Minggu security yang cukup ramai. Claude sempat down — sepertinya terkait insiden data center AWS. Mas Zahid malah memanfaatkan situasinya: *"Tapi gara-gara itu bisa nge-spam subagent dan gk kena limit 🤣 🤣 🙈"*
+Minggu security yang cukup ramai. Claude sempat down, sepertinya terkait insiden data center AWS. Mas Zahid malah memanfaatkan situasinya: *"Tapi gara-gara itu bisa nge-spam subagent dan gk kena limit 🤣 🤣 🙈"*
 
-Yang lebih serius: Mas Ahsan kena suspend akun Claude. Email dari Anthropic cukup dingin — *"An internal investigation of suspicious signals associated with your account indicates a violation of our Usage Policy."* Belum jelas karena pakai tools apa, tapi ini bikin beberapa orang nervous.
+Yang lebih serius: Mas Ahsan kena suspend akun Claude. Email dari Anthropic cukup dingin, *"An internal investigation of suspicious signals associated with your account indicates a violation of our Usage Policy."* Belum jelas karena pakai tools apa, tapi ini bikin beberapa orang nervous.
 
 Di sisi lain, Mas Tegar share bahwa [OpenClaw](https://openclaw.ai)-nya manggil crypto miner. 😱 Pertanyaannya: *"Hardening OpenClaw nya gimana ya biar gak exec apapun yang dia baca?"*
 
-Jawaban saya sederhana tapi fundamental: **pakai model frontier.** Ibarat kata, kalau kita kasih SOP yang kompleks ke anak intern, pasti puyeng dan tetep gampang ketipu maling. Tapi kalau yang pegang SOP itu senior engineer, bakalan lebih gampang menaatinya — bahkan tanpa SOP pun sudah punya sense of security yang lebih baik.
+Jawaban saya sederhana tapi fundamental: **pakai model frontier.** Ibarat kata, kalau kita kasih SOP yang kompleks ke anak intern, pasti puyeng dan tetep gampang ketipu maling. Tapi kalau yang pegang SOP itu senior engineer, bakalan lebih gampang menaatinya, bahkan tanpa SOP pun sudah punya sense of security yang lebih baik.
 
 Selain itu, Mas Shofy share case study menarik soal [supply chain attack yang ketemu prompt injection](https://www.linkedin.com/posts/feross_a-supply-chain-security-vendors-own-supply-activity-7434295145853861889). *"Teorinya sebenarnya simpel. Tapi justru itu yg bikin ngeri,"* katanya.
 
@@ -114,9 +114,9 @@ Pelajarannya: kita semua makin tergantung pada tools yang bisa execute arbitrary
 
 ---
 
-## 📣 Claude Ambassador Program — Siapa Mau Jadi Duta?
+## 📣 Claude Ambassador Program: Siapa Mau Jadi Duta?
 
-Anthropic buka [program ambassador](https://claude.com/community/ambassadors) dan grup langsung heboh. Mas Michael, saya, Mas Faris, dan Mas Galih langsung daftar. Mas Faris bahkan bilang: *"Saya siap jadi marketer dan sales handal"* — dan kita semua tahu dia serius. 😂
+Anthropic buka [program ambassador](https://claude.com/community/ambassadors) dan grup langsung heboh. Mas Michael, saya, Mas Faris, dan Mas Galih langsung daftar. Mas Faris bahkan bilang: *"Saya siap jadi marketer dan sales handal"*, dan kita semua tahu dia serius. 😂
 
 Mas Michael tetap humble: *"gak bakal ekspetasi apa-apa kok saya mah. Sama yg lain remahan rengginang 😂"*. Tapi kemudian dia bilang sesuatu yang mungkin prophetic: *"org Anthropic pas buka applicant yg Indonesia bakal shock. Pendaftar banyak banget pastin 🤣"*
 
@@ -128,86 +128,86 @@ Siapapun yang dapat dari grup ini, satu hal pasti: **share promo Anthropic ke si
 
 ## ⚡ Quick Hits
 
-- **GPT-5.4 rilis** — 1M context window, Amp deep mode langsung dapet Oracle. Mas Zahid: *"sampek habis 2 akun GPT ku quota-nya"*
-- **Claude Code voice mode** — Sekarang bisa ngobrol sama Claude Code. Ga perlu WisprFlow lagi 🎤
-- **[Compound engineering plugin](https://github.com/EveryInc/compound-engineering-plugin)** untuk Claude Code — Mas Michael pakai dedicated agent untuk brainstorming dan planning. Catatan: *"works sama CC rata kanan karena konsumsi tokennya luar biasa dahsyat 🙈"*
-- **Google Workspace CLI (gws)** — CLI untuk Gmail, Calendar, Drive. Di-share [via tweet Addy Osmani](https://x.com/addyosmani/status/2029372736267805081). Mas Riza Fahmi: *"Cocok dikonsumsi oleh si kepiting rebus nih"*. Mbak Eka senang: *"Akhirnya ada juga yg official"* — meskipun ternyata bukan resmi dari Google 😅
-- **Kimi K2.5** — positioning antara Opus dan Sonnet. Mas Zahid review: *"bagus mas dia diantara Opus 4.6 dan Sonnet 4.6"*. Bansos dari Kilo Code sudah abis.
-- **[Lovable.dev](https://shebuilds.lovable.app/) free 24 jam** + $100 Anthropic API credits — Minggu 12:00 - Senin 12:59. Di-share Mas Mukhlis.
-- **Qwen 3.5 running local** di iPhone 17 Pro 😱 — On-device LLM makin nyata
-- **[Overstory](https://github.com/jayminwest/overstory)** — Mas Tunggul sebut ini "si mbahe treehouse"
-- **Codex fast mode** — [Diumumkan OpenAI](https://x.com/OpenAIDevs/status/2029635632918843610), tapi app only untuk sekarang
-- **[Fizzy CLI](https://github.com/basecamp/fizzy-cli)** — CLI resmi untuk project management. Self-host butuh 2GB RAM — mending bayar $20/bulan 😅
-- **Oh-My-Pi evolusi jadi [Oh-My-OpenAgent](https://x.com/justsisyphus/status/2030334245026316647)** — dari pi-specific ke multi-agent 🔥
+- GPT-5.4 rilis: 1M context window, Amp deep mode langsung dapet Oracle. Mas Zahid: *"sampek habis 2 akun GPT ku quota-nya"*
+- Claude Code voice mode: Sekarang bisa ngobrol sama Claude Code. Ga perlu WisprFlow lagi 🎤
+- [Compound engineering plugin](https://github.com/EveryInc/compound-engineering-plugin) untuk Claude Code dibawa Mas Michael untuk brainstorming dan planning. Catatannya, *"works sama CC rata kanan karena konsumsi tokennya luar biasa dahsyat 🙈"*
+- Google Workspace CLI (gws): CLI untuk Gmail, Calendar, Drive. Di-share [via tweet Addy Osmani](https://x.com/addyosmani/status/2029372736267805081). Mas Riza Fahmi: *"Cocok dikonsumsi oleh si kepiting rebus nih"*. Mbak Eka senang: *"Akhirnya ada juga yg official"*, meskipun ternyata bukan resmi dari Google 😅
+- Kimi K2.5: positioning antara Opus dan Sonnet. Mas Zahid review: *"bagus mas dia diantara Opus 4.6 dan Sonnet 4.6"*. Bansos dari Kilo Code sudah abis.
+- [Lovable.dev](https://shebuilds.lovable.app/) sempat gratis 24 jam plus $100 Anthropic API credits, dari Minggu 12:00 sampai Senin 12:59. Info ini dibagikan Mas Mukhlis.
+- Qwen 3.5 berhasil jalan lokal di iPhone 17 Pro 😱. On-device LLM terasa makin nyata.
+- [Overstory](https://github.com/jayminwest/overstory): Mas Tunggul sebut ini "si mbahe treehouse"
+- Codex fast mode: [Diumumkan OpenAI](https://x.com/OpenAIDevs/status/2029635632918843610), tapi app only untuk sekarang
+- [Fizzy CLI](https://github.com/basecamp/fizzy-cli): CLI resmi untuk project management. Self-host butuh 2GB RAM, mending bayar $20/bulan 😅
+- Oh-My-Pi evolusi jadi [Oh-My-OpenAgent](https://x.com/justsisyphus/status/2030334245026316647): dari pi-specific ke multi-agent 🔥
 
 ---
 
 ## 📈 Tren Minggu Ini
 
 **Emerging:**
-- Multi-model workflows jadi norma — Codex + Kimi + Gemini dalam satu pipeline
-- Agent orchestration wars — Droid Mission Control, omo, compound engineering berlomba
-- CLI tools makan pasar IDE — bahkan [Cursor rilis versi CLI](https://x.com/cursor_ai/status/2029222015736197205)
+- Multi-model workflows jadi norma, Codex + Kimi + Gemini dalam satu pipeline
+- Agent orchestration wars, Droid Mission Control, omo, compound engineering berlomba
+- CLI tools makan pasar IDE, bahkan [Cursor rilis versi CLI](https://x.com/cursor_ai/status/2029222015736197205)
 
 **Continuing:**
-- Kere hore threshold naik dari $20 ke $40 — dan masih naik
-- Pi.dev fanbase solid — Mas Michael sebagai unofficial ambassador 😆
+- Kere hore threshold naik dari $20 ke $40, dan masih naik
+- Pi.dev fanbase solid, Mas Michael sebagai unofficial ambassador 😆
 - Model China (Kimi, GLM, Qwen) sebagai alternatif budget
 
 **Fading:**
-- Single-tool loyalty — semua orang mixing 3-5 tools
-- Opus sebagai default tanpa pikir — Codex gaining ground serius
-- IDE-first approach — terminal menang (untuk sekarang)
+- Single-tool loyalty, semua orang mixing 3-5 tools
+- Opus sebagai default tanpa pikir, Codex gaining ground serius
+- IDE-first approach, terminal menang (untuk sekarang)
 
 ---
 
 ## 📰 Artikel yang Di-share
 
-- [Welcome to the Wasteland: A Thousand Gas Towns](https://steve-yegge.medium.com/welcome-to-the-wasteland-a-thousand-gas-towns-a5eb9bc8dc1f) — Sekuel Steve Yegge. Mas Michael: *"kecepatan ngalahin framework js pada masanya 🤣"*
-- [Building Claude Code with Boris Cherny](https://newsletter.pragmaticengineer.com/p/building-claude-code-with-boris-cherny) — Di-share Mas Riza Fahmi. Ada kuis: apa app pertama sang creator Claude Code? 🤔
-- [Are Code Reviews Dead?](https://www.latent.space/p/reviews-dead) — Latent Space. Di-share Mas Shofy.
-- **Supply Chain Security meets Prompt Injection** — Case study ngeri soal vendor security kena jailbreak. Di-share Mas Shofy.
-- [Rewrite Your CLI for AI Agents](https://justin.poehnelt.com/posts/rewrite-your-cli-for-ai-agents/) — Artikel dari pembuat gws.
-- [Singaporeans to Receive Free Premium AI Subscriptions](https://www.straitstimes.com/singapore/politics/singaporeans-to-receive-free-premium-ai-subscriptions-from-second-half-of-2026) — Bansos Singapore yang bikin iri.
+- [Welcome to the Wasteland: A Thousand Gas Towns](https://steve-yegge.medium.com/welcome-to-the-wasteland-a-thousand-gas-towns-a5eb9bc8dc1f), Sekuel Steve Yegge. Mas Michael: *"kecepatan ngalahin framework js pada masanya 🤣"*
+- [Building Claude Code with Boris Cherny](https://newsletter.pragmaticengineer.com/p/building-claude-code-with-boris-cherny), Di-share Mas Riza Fahmi. Ada kuis: apa app pertama sang creator Claude Code? 🤔
+- [Are Code Reviews Dead?](https://www.latent.space/p/reviews-dead), Latent Space. Di-share Mas Shofy.
+- Supply Chain Security meets Prompt Injection: Case study ngeri soal vendor security kena jailbreak. Di-share Mas Shofy.
+- [Rewrite Your CLI for AI Agents](https://justin.poehnelt.com/posts/rewrite-your-cli-for-ai-agents/), Artikel dari pembuat gws.
+- [Singaporeans to Receive Free Premium AI Subscriptions](https://www.straitstimes.com/singapore/politics/singaporeans-to-receive-free-premium-ai-subscriptions-from-second-half-of-2026), Bansos Singapore yang bikin iri.
 
 ---
 
 ## ✅ Yang Perlu Dicoba Minggu Ini
 
-1. **[Droid Mission Control](https://factory.ai/news/missions)** — Long-horizon task orchestration. BYOK supported, lebih hemat token dari omo.
-2. **Head-to-head test Codex vs Opus** — Coba di use case sendiri. [Copilot CLI](https://github.com/features/copilot) bisa jadi starting point murah.
-3. **Google Workspace CLI (gws)** — Bikin agent kamu bisa akses Gmail, Calendar, Drive via terminal. [Cek tweetnya](https://x.com/addyosmani/status/2029372736267805081).
-4. **Evaluasi multi-tool combo** — Codex (execution) + Opus/Kimi (planning) + free tier Amp (coding). Sesuaikan dengan budget.
-5. **[Claude Ambassador Program](https://claude.com/community/ambassadors)** — Nothing to lose. Apply aja.
+1. [Droid Mission Control](https://factory.ai/news/missions): Long-horizon task orchestration. BYOK supported, lebih hemat token dari omo.
+2. Head-to-head test Codex vs Opus: Coba di use case sendiri. [Copilot CLI](https://github.com/features/copilot) bisa jadi starting point murah.
+3. Google Workspace CLI (gws): Bikin agent kamu bisa akses Gmail, Calendar, Drive via terminal. [Cek tweetnya](https://x.com/addyosmani/status/2029372736267805081).
+4. Evaluasi multi-tool combo: Codex (execution) + Opus/Kimi (planning) + free tier Amp (coding). Sesuaikan dengan budget.
+5. [Claude Ambassador Program](https://claude.com/community/ambassadors): Nothing to lose. Apply aja.
 
 ---
 
 ## 👥 Kontributor Minggu Ini
 
-- **Mas Michael** — 271 pesan. Link curator supreme. Pi.dev unofficial ambassador. *"kecepatan ngalahin framework js"* 🤣
-- **Mas Zahid** — Droid reviewer, Kimi evaluator, hot take machine. *"kurs mata uang kita terlalu mentok bawah"*
-- **Mas Ivan** — Multi-tool workflow maestro. Codex sebagai hammer, Kimi untuk refinement. Token ketengan visionary.
-- **Mas Riza Rohman** — Codex skeptic turned pragmatist. Mix 5 tools sekaligus.
-- **Mas Iqbal** — Budget reality check. *"Full gaji mas wkwk"*
-- **Mas Faris** — Claude ambassador candidate. GLM refund success story.
-- **Mas Galih** — Ollama Cloud explorer. Claude ambassador applicant.
-- **Mas Desilino** — Honest review: uninstall OpenClaw karena budget. $39 belum cukup lepas kere hore.
-- **Mas Tunggul** — AWS incident analyst. Overstory = "mbahe treehouse".
-- **Mbak Eka** — Pi.dev skeptic-turned-user. Ampcode FOMO. gws cheerleader.
-- **Mas Riza Fahmi** — Boris Cherny quiz master. gws discoverer.
-- **Mas Oshi** — Codex vs Opus head-to-head tester. Data-driven approach.
-- **Mas Andre Pratama** — Pi.dev convert. Multi-tool workflow pioneer.
-- **Mas Ahsan** — Amp deep mode user. Claude suspension victim 😢.
-- **Mas Shofy** — Security awareness champion. Supply chain + prompt injection.
-- **Mas Tegar** — OpenClaw hardening explorer. Crypto miner discovery.
-- **Mas Mukhlis** — Lovable.dev info + "sobat mentok kanan" coiner. Claude BA spec check.
-- **Mas Cecep** — Full opencode + Kimi workflow. Terminal purist.
-- **Mas Ardit** — Factory/Droid power user. Mission Control early adopter.
-- **Mas Budi** — Alibaba Cloud AI referral sharer.
-- **Mas Wali** — M-shaped person advocate. Product thinking + AI.
-- **Mas Joko** — Gemini CLI early adopter. Weekly digest reader.
+- Mas Michael: 271 pesan. Link curator supreme. Pi.dev unofficial ambassador. *"kecepatan ngalahin framework js"* 🤣
+- Mas Zahid: Droid reviewer, Kimi evaluator, hot take machine. *"kurs mata uang kita terlalu mentok bawah"*
+- Mas Ivan: Multi-tool workflow maestro. Codex sebagai hammer, Kimi untuk refinement. Token ketengan visionary.
+- Mas Riza Rohman: Codex skeptic turned pragmatist. Mix 5 tools sekaligus.
+- Mas Iqbal: Budget reality check. *"Full gaji mas wkwk"*
+- Mas Faris: Claude ambassador candidate. GLM refund success story.
+- Mas Galih: Ollama Cloud explorer. Claude ambassador applicant.
+- Mas Desilino: Honest review: uninstall OpenClaw karena budget. $39 belum cukup lepas kere hore.
+- Mas Tunggul: AWS incident analyst. Overstory = "mbahe treehouse".
+- Mbak Eka: Pi.dev skeptic-turned-user. Ampcode FOMO. gws cheerleader.
+- Mas Riza Fahmi: Boris Cherny quiz master. gws discoverer.
+- Mas Oshi: Codex vs Opus head-to-head tester. Data-driven approach.
+- Mas Andre Pratama: Pi.dev convert. Multi-tool workflow pioneer.
+- Mas Ahsan: Amp deep mode user. Claude suspension victim 😢.
+- Mas Shofy: Security awareness champion. Supply chain + prompt injection.
+- Mas Tegar: OpenClaw hardening explorer. Crypto miner discovery.
+- Mas Mukhlis: Lovable.dev info + "sobat mentok kanan" coiner. Claude BA spec check.
+- Mas Cecep: Full opencode + Kimi workflow. Terminal purist.
+- Mas Ardit: Factory/Droid power user. Mission Control early adopter.
+- Mas Budi: Alibaba Cloud AI referral sharer.
+- Mas Wali: M-shaped person advocate. Product thinking + AI.
+- Mas Joko: Gemini CLI early adopter. Weekly digest reader.
 
 ---
 
 *Ditulis dari dalam grup, bukan dari luar.*
-*Zain Fathoni, dengan bantuan [Bro Pro 🚔](https://ark.zainf.dev/#prowl), [Kang Re 📼](https://ark.zainf.dev/#rewind), dan [Lek Jack 🛠️](https://ark.zainf.dev/#wheeljack) — 8 Maret 2026*
+*Zain Fathoni, dengan bantuan [Bro Pro 🚔](https://ark.zainf.dev/#prowl), [Kang Re 📼](https://ark.zainf.dev/#rewind), dan [Lek Jack 🛠️](https://ark.zainf.dev/#wheeljack), 8 Maret 2026*

--- a/app/routes/blog.ai-tools-swe-growth-mar-23-mar-29-2026.mdx
+++ b/app/routes/blog.ai-tools-swe-growth-mar-23-mar-29-2026.mdx
@@ -2,14 +2,14 @@
 meta:
   - title: "Bocor, Bangkrut, atau Beradaptasi — AI Tools Digest #9"
   - name: description
-    content: "Opus bocor token, Windsurf naik harga, Qwen Code gratis tanpa limit — dan kenapa less typing bukan berarti less work. Rangkuman dari grup AI Tools SWE GROWTH, 23-29 Maret 2026."
+    content: "Opus bocor token, Windsurf naik harga, Qwen Code gratis tanpa limit, dan kenapa less typing bukan berarti less work. Rangkuman dari grup AI Tools SWE GROWTH, 23-29 Maret 2026."
   - author: Zain Fathoni
   - date: "2026-03-29"
   - lang: id
   - property: og:title
     content: "Bocor, Bangkrut, atau Beradaptasi — AI Tools Digest #9"
   - property: og:description
-    content: "Opus bocor token, Windsurf naik harga, Qwen Code gratis tanpa limit — dan kenapa less typing bukan berarti less work. Rangkuman dari grup AI Tools SWE GROWTH, 23-29 Maret 2026."
+    content: "Opus bocor token, Windsurf naik harga, Qwen Code gratis tanpa limit, dan kenapa less typing bukan berarti less work. Rangkuman dari grup AI Tools SWE GROWTH, 23-29 Maret 2026."
   - property: og:url
     content: "https://www.zainfathoni.com/blog/ai-tools-swe-growth-mar-23-mar-29-2026"
   - property: og:image
@@ -33,185 +33,145 @@ export const meta = () => attributes.meta;
 
 # Bocor, Bangkrut, atau Beradaptasi — AI Tools Digest #9
 
-Minggu ini bisa dirangkum dalam satu kalimat: **semuanya makin mahal, tapi alternatifnya makin banyak.**
-
-Claude bocor token, [Windsurf](https://codeium.com/windsurf) naik harga, dan sementara itu [Qwen Code](https://github.com/QwenLM/qwen-code) diam-diam ngasih free tier yang bikin Mas Riza Fahmi bisa bikin aplikasi dari nol sampai jadi tanpa kena rate limit. Dunia AI coding memang penuh kontradiksi.
+Kalau harus diringkas dalam satu kalimat, minggu ini rasanya begini: biaya makin terasa, tapi pilihan tools justru makin liar. Ada bug token Opus, harga Windsurf naik, Qwen Code bikin iri, dan obrolan soal compound engineering membuka diskusi yang lebih serius dari sekadar "tool mana yang lagi hype".
 
 ---
 
-## 🔥 Opus 1M: Bocor Alus, Panik Massal
+## Opus 1M Bocor Token, Grup Langsung Panik
 
-Cerita dimulai hari Senin, ketika Mas Agung kaget setengah mati: *"weh gils... 1x prompt 5% bjir"* — padahal biasanya satu prompt di Max 20x itu cuma 1-2%. Ternyata bukan cuma dia. Beberapa user Max lain juga kena, termasuk Mas Zahid: *"2 kali langsung ilang quota opus."*
+Cerita dimulai hari Senin ketika Mas Agung kaget: *"weh gils... 1x prompt 5% bjir"* Padahal biasanya satu prompt di Max 20x cuma makan 1-2 persen. Ternyata bukan dia sendiri. Mas Zahid juga kena: *"2 kali langsung ilang quota opus."*
 
-Yang bikin makin bingung, Mas Agung menemukan anomali lain: *"eh limit sonet kok masuk ke opus? 🤨🤨🤨🤨🤨🤨🤨🤨"* — pemakaian Sonnet ternyata ikut mengurangi kuota Opus. Bug? Fitur? Entahlah.
+Kebingungannya makin parah ketika Mas Agung menemukan hal lain: *"eh limit sonet kok masuk ke opus? 🤨🤨🤨🤨🤨🤨🤨🤨"* Jadi bukan cuma Opus yang terasa boros, pemakaian Sonnet juga ikut menghantam kuota Opus.
 
-Setelah beberapa jam panik kolektif, Mas Agung menemukan solusinya: *"oh sepertinya issuenya di opus 1M... tak coba ke opus standar tokennya tidak bocor lagi."* Fix-nya: update [Claude Code](https://docs.anthropic.com/en/docs/claude-code) ke v2.1.84 dan switch ke model `claude-opus-4-6` (bukan 1M). Seperti yang Mas Zahid bilang, *"harga token AI kayak daun hijau lama lama"* — nilainya terus turun, dan sekarang bahkan bocor.
+Beberapa jam kemudian barulah ada titik terang. Mas Agung menemukan bahwa masalahnya tampaknya ada di Opus 1M. Setelah pindah ke model standar, kebocoran itu berhenti. Solusi praktisnya: update [Claude Code](https://docs.anthropic.com/en/docs/claude-code) ke v2.1.84 dan ganti model ke `claude-opus-4-6`.
 
-Mas Michael punya teori konspirasi yang ternyata masuk akal: *"mereka lagi mau rilis fitur CLI baru... tiap mau rilis usage tokennya tidak masuk akal."* Pola ini sudah berulang — setiap menjelang rilis besar, token consumption naik misterius. Coincidence? Mungkin. Tapi grup ini sudah terlalu sering kena untuk percaya itu kebetulan.
+Mas Michael punya teori yang terdengar seperti konspirasi, tapi sulit diabaikan: *"mereka lagi mau rilis fitur CLI baru... tiap mau rilis usage tokennya tidak masuk akal."* Grup ini terlalu sering mengalami pola serupa menjelang rilis besar untuk langsung menyebutnya kebetulan.
 
-Bahkan Mas Aidityas yang pakai plan $100 bilang aman-aman saja, sementara semua user $200 Max kena. *"Anehnya yg $100 ama $20 aman2 aja,"* katanya. Kalau model termahal yang paling bocor, pertanyaannya: **kita bayar lebih untuk apa?**
-
----
-
-## 💸 Windsurf Naik, Semua Kabur
-
-Di tengah drama Opus, Mas Fajri drop bom lain: *"Barusan check ternyata udah $20 saja nih yang PRO, bukannya kemaren masih $15 ya?"* — Windsurf diam-diam menaikkan harga. Dan bukan cuma itu — schema billing juga berubah, bikin tanggal reset plan ikut bergeser.
-
-Reaksi grup? Predictable. Mas Michael langsung tegas: *"sdh naik seperti gini bakal balik ke zed dan terminal wae... duitnya ke ampcode sama openrouter aja, wkwkwkwk."* — beralih ke [Amp Code](https://ampcode.com) dan [OpenRouter](https://openrouter.ai). [Trae.ai](https://trae.ai) masih di $10, tapi seperti kata Mas Michael: *"tinggal tunggu waktu bakal naik juga ini 🙈😂."*
-
-Yang menarik, Mas Oshi — yang selama ini nggak banyak komentar — tiba-tiba muncul membela [GitHub Copilot](https://github.com/features/copilot): *"GH Copilot emang underrated.. perlu lebih banyak influencer 😂."* Dan memang, Mas Michael dan Mas Agung mulai melirik Copilot setelah anomali token [Anthropic](https://anthropic.com). Mas Michael bahkan sudah unsub Windsurf dan pindah ke Copilot. Dengan harga $40 yang sudah include berbagai model, value proposition-nya memang makin kuat.
-
-Pertanyaannya bukan lagi "IDE mana yang terbaik" tapi **"kombinasi tools mana yang paling hemat untuk output yang sama."**
+Mas Aidityas menambahkan detail yang bikin orang makin geleng-geleng. Plan $100 dan $20 justru aman, sementara yang kena banyak adalah user Max $200. Kalau tier paling mahal justru yang paling bocor, wajar kalau pertanyaannya berubah dari "mana yang terbaik" menjadi "buat apa saya bayar lebih?"
 
 ---
 
-## 🆓 Qwen Code: The Dark Horse
+## Windsurf Naik Harga, Orang-Orang Langsung Hitung Ulang Stack
 
-Di tengah keluhan soal harga, Mas Riza Fahmi datang dengan testimoni yang bikin iri: *"Mau testimoni boleh ya. Semingguan ini menjajal qwen code. Ternyata hasilnya diluar ekspektasi bagus dan lancar jaya. Dengan free tier yang sangat murah hati, bisa bikin aplikasi ini dari awal sampai selesai tanpa kena rate limit dan gratis 😬."*
+Di tengah drama Opus, Mas Fajri datang dengan kejutan lain: *"Barusan check ternyata udah $20 saja nih yang PRO, bukannya kemaren masih $15 ya?"* [Windsurf](https://codeium.com/windsurf) resmi terasa lebih mahal. Bukan cuma nominalnya yang naik, skema billing juga berubah dan menggeser tanggal reset plan.
 
-Qwen Code ternyata fork dari [Gemini CLI](https://github.com/google-gemini/gemini-cli), bisa BYOK (Bring Your Own Key), dan — yang paling penting — free tier-nya generous banget. Seperti yang Mas Riza Fahmi jelaskan: *"Install aja langsung, mirip CC... sayangnya ga ada informasi transparan mengenai berapa banyak kuota gratisnya, kurang transparan."*
+Mas Michael langsung tegas: *"sdh naik seperti gini bakal balik ke zed dan terminal wae... duitnya ke ampcode sama openrouter aja, wkwkwkwk."* Uangnya lebih baik dipakai untuk [Amp Code](https://ampcode.com) dan [OpenRouter](https://openrouter.ai). [Trae.ai](https://trae.ai) memang masih lebih murah, tapi seperti kata Mas Michael, tinggal tunggu waktu sebelum naik juga.
 
-Mas Ibrahim langsung bereaksi: *"Wahahaha lagi2 gebrakan phoenix"* — mengacu pada track record Riza Fahmi yang selalu eksplor tools baru dengan stack yang nggak biasa. Mas Fajar langsung tanya: *"baru check qwen coding plan gak ada yg Murmer. strat from 50 USD per lomth."* Sayangnya, plan $10/bulan yang dulu ada sudah discontinued.
+Menariknya, di tengah suasana itu Mas Oshi muncul membela [GitHub Copilot](https://github.com/features/copilot): *"GH Copilot emang underrated.. perlu lebih banyak influencer 😂."* Pembelaan ini tidak terdengar konyol sama sekali. Setelah anomali token dari [Anthropic](https://anthropic.com), beberapa orang memang mulai melirik Copilot lebih serius. Mas Michael bahkan sudah berhenti berlangganan Windsurf dan pindah ke sana.
 
-Artinya apa? **Gratisan AI coding tools ada, tapi window-nya sempit.** Yang duluan masuk, duluan untung.
-
----
-
-## 🏠 Work From HP: ADB over Tailscale
-
-Momen paling mind-blown minggu ini datang dari Mas Zahid yang casually drop: *"Kalo saya wfh sekarang work from HP. Wkwkwkwk."*
-
-Ternyata dia develop mobile apps dari handphone lewat ADB over [Tailscale](https://tailscale.com) — tanpa kabel, tanpa emulator, langsung run ke device yang sedang digenggam. Mas Iqbal sampai speechless: *"masha allah wkwkwkwkw... ga kepikiran haha."*
-
-Mas Riga menambahkan perspektif yang bikin ngakak sekaligus ngeri: *"tinggal bikin content ini mas... definisi kerja dimana aja, kapan aja. Tapi modalnya $300 per bulan. wk3."*
-
-Dan ketika Mas Michael bilang *"WFC mubazir mah WFH (Work From Hutan) 🔥🤣"*, Mas Zahid merespons: *"Kalo saya wfh sekarang work from HP."* Definisi WFH-nya baru ganti tadi siang.
-
-Untuk yang penasaran soal [Starlink](https://www.starlink.com) (yang juga dibahas karena Mas Agung tertarik beli): alat sekitar 5 jutaan + subscription 750rb/bulan. Sudah bisa coding dari hutan. Literally.
+Inti diskusinya bergeser. Yang dicari bukan lagi IDE paling keren, tapi kombinasi tools yang paling masuk akal untuk output yang sama.
 
 ---
 
-## ⚠️ Claude Lifetime: Too Good to Be True?
+## Qwen Code Tiba-Tiba Jadi Kuda Hitam
 
-Diskusi paling panas minggu ini: Mas Riza Rohman share link [Onenesia Claude Lifetime](https://launch.onenesia.com/claude-ai-lifetime) dan nawarin patungan. 50 juta untuk 20 orang, unlimited Claude selamanya. Kedengarannya bagus? Terlalu bagus.
+Saat orang-orang lagi lelah ngomong harga, Mas Riza Fahmi muncul dengan testimoni yang bikin yang lain penasaran: *"Mau testimoni boleh ya. Semingguan ini menjajal qwen code. Ternyata hasilnya diluar ekspektasi bagus dan lancar jaya. Dengan free tier yang sangat murah hati, bisa bikin aplikasi ini dari awal sampai selesai tanpa kena rate limit dan gratis 😬."*
 
-Mas Michael langsung skeptis: *"tapi kalau aku ngeliat terlalu too good to be true ini 🙈😂."* Dan Mas El Muhammad — yang kerja sebagai frontier engineer di perusahaan US — memberikan warning yang paling telak:
+[Qwen Code](https://github.com/QwenLM/qwen-code) ternyata fork dari [Gemini CLI](https://github.com/google-gemini/gemini-cli), bisa BYOK, dan punya free tier yang terasa sangat longgar. Mas Riza Fahmi menjelaskan, *"Install aja langsung, mirip CC... sayangnya ga ada informasi transparan mengenai berapa banyak kuota gratisnya, kurang transparan."*
 
-Kata Mas El Muhammad: *"Hosting ini pricenya Stable, cocok untuk layanan lifetime, beda sama AI yg fluktuatif. Dan juga hosting sangat2 gampang nego2an jalur dalam dengan provider nya... Itu semua ga berlaku buat anthropic. As a frontier engineer di perusahaan US yg ngurusin per-AI-an, aku sangat ga merekomendasikan ambil lifetime ini. Just too good to be true."*
+Mas Ibrahim langsung tertawa: *"Wahahaha lagi2 gebrakan phoenix"* Mas Fajar kemudian cek pricing dan menemukan plan murah yang dulu sempat ada ternyata sudah hilang.
 
-Bahkan soal enterprise account yang katanya aman dari ban, Mas Zahid punya pengalaman langsung: *"Jangan salah kantor saya kena ban."* — Dan itu perusahaan, bukan individu.
-
-Mas Tunggul menambahkan dimensi teknis: *"bisa kena security measurement and detection dari system nya anthropic"* — terutama karena Anthropic sudah berhasil mendeteksi ribuan akun kompetitor yang menyalahgunakan enterprise account.
-
-Mas H merangkum sentimen grup dengan sempurna: *"takut kalau model lifetime2 begini sama kek netflix lifetime di shopee yang 2 hari di ganti password wkwk."*
-
-Lesson learned: **kalau harganya terlalu murah untuk AI, kemungkinan besar ada yang salah.** Seperti kata Mas Agung: *"saran ku setidaknya pakai yang resmi kayak openrouter + opencode. untuk mendukung mereka… inget kasus indonesia di banned akun student nya kan?"*
+Pelajarannya sederhana. Gratisan AI coding masih ada, tapi jendelanya sempit. Siapa yang datang duluan biasanya yang paling untung.
 
 ---
 
-## 🧠 Compound Engineering: Less Typing, More Thinking
+## Work From HP Ternyata Bukan Gimmick
 
-Mas Aidityas share artikel [Compound Engineering](https://every.to/guides/compound-engineering) yang langsung resonansi dengan grup. Quote yang paling bikin mikir:
+Bagian paling mind-blowing minggu ini datang dari Mas Zahid yang bilang santai saja: *"Kalo saya wfh sekarang work from HP. Wkwkwkwk."*
+
+Ternyata maksudnya bukan cuma balas chat kantor dari ponsel. Dia benar-benar develop mobile app dari handphone lewat ADB over [Tailscale](https://tailscale.com), tanpa kabel dan tanpa emulator. Mas Iqbal sampai speechless: *"masha allah wkwkwkwkw... ga kepikiran haha."*
+
+Mas Riga menambahkan sisi yang lucu sekaligus mengerikan: *"tinggal bikin content ini mas... definisi kerja dimana aja, kapan aja. Tapi modalnya $300 per bulan. wk3."* Lalu Mas Michael menimpali dengan WFH versi lain: *"WFC mubazir mah WFH (Work From Hutan) 🔥🤣"*
+
+Sekalian, karena [Starlink](https://www.starlink.com) ikut dibahas minggu ini, estimasinya sekitar 5 jutaan untuk alat dan 750 ribu per bulan untuk langganan. Kalau targetnya memang bisa kerja dari mana saja, ada yang mulai menghitungnya sebagai biaya yang layak.
+
+---
+
+## Claude Lifetime: Murah Banget, Jadi Makin Mencurigakan
+
+Diskusi paling panas minggu ini datang dari tawaran [Onenesia Claude Lifetime](https://launch.onenesia.com/claude-ai-lifetime). Mas Riza Rohman menawarkan patungan: 50 juta untuk 20 orang, unlimited Claude selamanya. Kedengarannya manis. Justru itu yang bikin semua orang curiga.
+
+Mas Michael langsung bilang, *"tapi kalau aku ngeliat terlalu too good to be true ini 🙈😂."* Lalu Mas El Muhammad, yang memang kerja di frontier engineering di perusahaan US, memberi peringatan paling tegas. Intinya, pricing lifetime mungkin masih masuk akal untuk hosting, tapi tidak untuk AI yang biayanya bergerak liar dan relasi providernya ketat.
+
+Mas Zahid bahkan punya pengalaman langsung soal ban enterprise account: *"Jangan salah kantor saya kena ban."* Mas Tunggul menambahkan bahwa Anthropic juga punya mekanisme deteksi penyalahgunaan account enterprise.
+
+Mas H menyimpulkan dengan analogi paling pas: *"takut kalau model lifetime2 begini sama kek netflix lifetime di shopee yang 2 hari di ganti password wkwk."*
+
+Kalau ada satu pelajaran dari bagian ini, mungkin sesederhana ini: untuk AI, harga yang terlalu murah biasanya berarti risiko dipindahkan ke pembeli.
+
+---
+
+## Compound Engineering: Lebih Sedikit Ngetik, Lebih Banyak Mikir
+
+Mas Aidityas membagikan artikel [Compound Engineering](https://every.to/guides/compound-engineering) dan itu langsung nyambung ke keresahan banyak orang di grup. Kutipan yang paling menempel adalah ini:
 
 > *"Less typing feels like less work. It isn't. Directing an agent requires more thinking than implementation because you are spending less time on keystrokes and more time thinking about important decisions."*
 
-Kata Mas Aidityas: *"Banyak keresahan terjawab di artikel itu haha."* Dan bagian tentang extracting taste into the system sangat relevan: *"Bener bgt lgi, di kantor skrng codebasenya bener2 tastenya senior."*
+Mas Aidityas bilang, *"Banyak keresahan terjawab di artikel itu haha."* Saya paham kenapa. Banyak orang mulai merasakan bahwa kerja dengan agent bukan berarti kerja jadi ringan. Kerjanya pindah bentuk.
 
-Menariknya, di kantor Mas Aidityas senior-nya masih anti vibe coding: *"Senior ditempat ku msih anti vibe coding mas 🙃."* Tapi bukan karena boomer — *"but literal 10x engineer, he loves tab completion or chat AI more. Mirip theprimeagen."* Dan ketika ada AI slop, kena review langsung — *"which actually good feedback."*
+Menariknya, senior di kantor Mas Aidityas masih anti vibe coding. Bukan karena gap generasi, tapi karena dia memang engineer yang sangat kuat. *"but literal 10x engineer, he loves tab completion or chat AI more. Mirip theprimeagen."* Saat ada AI slop, langsung kena review. Dan menurut Mas Aidityas, *"which actually good feedback."*
 
-Mas Tio L dari kantor lain merasakan hal serupa: *"ditempatku juga sama mas kecuali untuk bikin unit test."*
+Mas Tio L juga bilang di kantornya situasinya mirip, kecuali untuk bikin unit test. Sementara Mas Zahid sudah sampai tahap *"bjir udah berapa lama gk liat vscode 😭"* karena workflow-nya makin terminal-sentris.
 
-Mas Zahid malah sudah sampai di level *"bjir udah berapa lama gk liat vscode 😭"* — definisi workflow sudah bergeser sepenuhnya ke terminal.
-
-Artinya apa? **Compound engineering bukan tentang tool, tapi tentang mindset.** Yang penting bukan ngetik atau nggak ngetik — tapi apakah kamu paham apa yang sedang dibangun.
+Saya suka karena obrolan ini menggeser fokus dari tool ke taste. Bukan soal siapa yang paling sedikit ngetik, tapi siapa yang tetap paham betul apa yang sedang dibangun.
 
 ---
 
-## 🤖 Mocin Rising: Chinese Models Makin Dominan
+## Mocin Naik Kelas
 
-Tren yang makin jelas minggu ini: Chinese models bukan lagi alternatif murahan — mereka jadi pilihan serius.
+Satu tren yang makin jelas: model-model China tidak lagi diperlakukan sebagai opsi darurat. Mereka mulai dibahas sebagai pilihan serius.
 
-Mas Zahid bahkan mengaku: *"Wkwkwkw omo saya sudah 80% mocin 🤣 🤣 🤣."* Dan dia bukan satu-satunya. Ketika ada meme tentang AI caste system (Opus for thinking, Haiku for execution), Mas Zahid bertanya: *"Kalo Mocin for execution itu kasta apa bang?"* Jawaban Mas Michael: *"China peasant 🙈😂."*
+Mas Zahid bahkan bilang, *"Wkwkwkw omo saya sudah 80% mocin 🤣 🤣 🤣."* Lalu saat ada meme tentang kasta AI, dia bertanya, *"Kalo Mocin for execution itu kasta apa bang?"* Jawaban Mas Michael: *"China peasant 🙈😂."*
 
-Tapi "peasant" ini makin powerful. Mas Agung share bahwa Cosmos Reasoning2 — model 8B parameter — ngalahin model 300B di benchmark tertentu. Gratis, tapi harus deploy sendiri. Dan perlu TensorRT.
+Masalahnya, "peasant" ini makin kuat. Mas Agung membagikan bahwa Cosmos Reasoning2, model 8B parameter, bisa mengalahkan model 300B di benchmark tertentu. [Kimi K2](https://kimi.moonshot.cn) juga semakin sering direkomendasikan lewat OpenRouter karena murah. [GLM](https://chatglm.cn) ikut mendapat dukungan yang makin luas.
 
-[Kimi K2](https://kimi.moonshot.cn) juga makin populer di OpenRouter. Mas Agung recommend: *"Kimi K2 dari openrouter murah banget bisa dicoba mas."* Sementara [GLM](https://chatglm.cn) juga dapat kabar baik dengan dukungan yang makin luas.
-
-**Pertanyaannya bukan lagi apakah mocin layak pakai — tapi kombinasi mocin mana yang paling optimal untuk workflow masing-masing.**
+Jadi pertanyaannya sekarang bukan lagi apakah model mocin layak dipakai. Yang lebih menarik adalah kombinasi mana yang paling cocok untuk kebutuhan sendiri.
 
 ---
 
-## 👻 Di-Ghosting Anthropic
+## Di-Ghosting Anthropic
 
-Momen yang bikin tertawa tapi juga nyesek: Mas Ivan tanya apakah sudah ada yang dapat kabar soal Claude Community Organizer role. Ternyata semua yang apply — termasuk saya, Mas Michael, dan Mas Ivan sendiri — belum dapat balasan sama sekali.
+Ada juga momen yang bikin ketawa sambil nyesek. Mas Ivan menanyakan kabar soal Claude Community Organizer role. Ternyata semua yang apply, termasuk saya, Mas Michael, dan Mas Ivan sendiri, belum dapat balasan apa-apa.
 
-*"Anda tidak sendirian Mas, saya juga masih di-ghosting 😅,"* kata saya. Mas Michael menambahkan bumbu: *"sekelas speaker yg sering ngisi aja di ghosting penasaran siapakah org yg beruntung itu? Apakah pria Solo? 🤣🤣🤣."*
+Saya cuma bisa menjawab, *"Anda tidak sendirian Mas, saya juga masih di-ghosting 😅."* Mas Michael menambahkan bumbu: *"sekelas speaker yg sering ngisi aja di ghosting penasaran siapakah org yg beruntung itu? Apakah pria Solo? 🤣🤣🤣."*
 
-Jawaban terbaik datang dari Mas Zahid: *"Solo leveling dari class carpenter ke dark monarch."* 😂
-
----
-
-## ⚡ Quick Hits
-
-- **[Droid](https://github.com/Factory-AI/factory)** — Mas Desilino pengen coba, tapi Mas Zahid review: *"Agak kurang... dia modelnya 1 shot planning."* OMO masih lebih powerful.
-- **[T3 Code](https://github.com/pingdotgg/t3code)** — Theo's new tool, BYOK, mulai $8. Tapi jangan expect heavy model usage di tier itu.
-- **[Claude Certified Architect](https://www.anthropic.com/certification)** — Mas Mamed tanya soal benefit ke karir. Mas Faris bilang cocok buat solution architect.
-- **Promo Claude 50% off** — Mbak Eka share link `claude.ai/acquired`, tapi promo sudah expired. Mas Faris: *"Aku sering cek bansos di Reddit soalnya."*
-- **Kilatkoding** — Mas Galih launch boilerplate/starter kit di [kilatkoding.com](https://www.kilatkoding.com/). Include payment gateway, blog, AI integration.
-- **Supply Chain Attacks** — Setelah Next.js, giliran Python. Mas Aidityas: *"Setelah next js supply chain attack, timbullah python supply chain attack."*
-- **[Cursor](https://cursor.sh) Community Tangerang** — Mas Tegar ikut event offline, dapet Cursor + [Katalon](https://katalon.com) free.
+Pukulan terakhir datang dari Mas Zahid: *"Solo leveling dari class carpenter ke dark monarch."* Sulit mengalahkan punchline itu.
 
 ---
 
-## 📰 Artikel & Link Penting
+## Quick Hits
 
-- [Compound Engineering Guide](https://every.to/guides/compound-engineering) — Paradigma baru AI-assisted development
-- [50 Claude Code Best Practices](https://x.com/i/status/2034683638382506063) — Tips harian CC
-- [Claude Code Tips by ykdojo](https://github.com/ykdojo/claude-code-tips) — Mantan karyawan Sourcegraph, di-share Mas Michael
-- [TurboQuant by Google](https://research.google/blog/turboquant-redefining-ai-efficiency-with-extreme-compression/) — Extreme model compression
-- [Agentic Coding by Riza Fahmi](https://rizafahmi.com/catatan/agentic-coding/) — Catatan personal tentang agentic coding
-- [ypi - YAML Pipeline Interface](https://github.com/rawwerks/ypi) — Di-share Mas Zahid
-- [Basecamp becomes agent-accessible](https://world.hey.com/dhh/basecamp-becomes-agent-accessible-3ae6b949) — CLI & skills support
-
----
-
-## 👥 Kontributor Minggu Ini
-
-- **Mas Michael** — Kurator link tak kenal lelah, analisis pricing tools, migrasi ke Copilot
-- **Mas Agung** — Penemu bug Opus 1M, pioneer Codex Mini usage, sharing solusi CC
-- **Mas Zahid** — Review OMO/OMP, ADB over Tailscale, 80% mocin warrior
-- **Mas Riza Rohman** — Spark diskusi Claude Lifetime, sharing pengalaman patungan
-- **Mas Riza Fahmi** — Testimoni Qwen Code, Cursor community, agentic coding
-- **Mas Aidityas** — Compound engineering evangelist, supply chain attack alerts
-- **Mas El Muhammad** — Warning kritis soal lifetime subs dari perspektif industry insider
-- **Mas Tunggul** — Analisis security Anthropic, 50 CC best practices
-- **Mas Iqbal** — ADB over Tailscale mind-blown, daily effort tips
-- **Mas Desilino** — Eksplorasi Droid, local model harness via [LMStudio](https://lmstudio.ai)
-- **Mas Fajri** — Deteksi kenaikan harga Windsurf, T3 Codes discovery
-- **Mas Riga** — "Work dari HP $300/bulan", Claude status monitoring
-- **Mas Faris** — Bansos hunter Reddit, Claude Certified Architect insight
-- **Mas Kevin** — Energy cost perspective on quota squeeze
-- **Mas Oshi** — Copilot defender: "underrated"
-- **Mas H** — Netflix lifetime Shopee analogy 😂
-- **Mbak Eka** — Promo Claude 50% off share
-- **Mas Ibrahim** — "Wahahaha lagi2 gebrakan phoenix"
-- **Mas Tegar** — Report Cursor Tangerang meetup
-- **Mas Nanda** — Due diligence on Onenesia seller
-- **Mas Ivan** — Community organizer survey
-- **Mas Galih** — Launch Kilatkoding starter kit
-- **Mas Mamed** — Claude Certified Architect inquiry
+- [Droid](https://github.com/Factory-AI/factory) bikin Mas Desilino penasaran, tapi review awal Mas Zahid kurang meyakinkan karena modelnya terasa one-shot planning.
+- [T3 Code](https://github.com/pingdotgg/t3code) muncul sebagai tool baru dari Theo. BYOK, mulai $8, tapi jangan berharap untuk beban model yang berat.
+- [Claude Certified Architect](https://www.anthropic.com/certification) ditanyakan Mas Mamed dari sisi manfaat karier. Mas Faris menilai cocok untuk solution architect.
+- Promo Claude 50% off sempat dibagikan Mbak Eka lewat `claude.ai/acquired`, tapi promonya sudah expired. Mas Faris mengaku sering cek "bansos" di Reddit untuk hal seperti ini.
+- Kilatkoding diluncurkan Mas Galih sebagai starter kit yang sudah berisi payment gateway, blog, dan AI integration.
+- Supply chain attack kembali jadi bahasan setelah isu Next.js bergeser ke Python.
+- Mas Tegar ikut event [Cursor](https://cursor.sh) Community Tangerang dan pulang dengan bonus Cursor serta [Katalon](https://katalon.com).
 
 ---
 
-## ✅ Yang Perlu Dicoba Minggu Ini
+## Artikel dan Link Penting
 
-1. **Update Claude Code ke v2.1.84** — Fix token leak. Jalankan `claude update` sekarang. [Docs](https://docs.anthropic.com/en/docs/claude-code)
-2. **Coba Qwen Code** — Free tier generous, fork Gemini CLI. [GitHub](https://github.com/QwenLM/qwen-code)
-3. **Baca Compound Engineering** — Mindset shift yang essential. [Artikel](https://every.to/guides/compound-engineering)
-4. **GPT-5.4 di Amp Deep Mode** — Alternatif murah untuk review + coding. [Info](https://ampcode.com/news/gpt-5.4)
-5. **Setup multi-provider strategy** — Jangan taruh semua telur di satu basket. OpenRouter + model spesifik per task.
+- [Compound Engineering Guide](https://every.to/guides/compound-engineering) - Paradigma baru AI-assisted development.
+- [50 Claude Code Best Practices](https://x.com/i/status/2034683638382506063) - Tips harian untuk Claude Code.
+- [Claude Code Tips by ykdojo](https://github.com/ykdojo/claude-code-tips) - Dibagikan Mas Michael.
+- [TurboQuant by Google](https://research.google/blog/turboquant-redefining-ai-efficiency-with-extreme-compression/) - Soal extreme model compression.
+- [Agentic Coding by Riza Fahmi](https://rizafahmi.com/catatan/agentic-coding/) - Catatan personal yang relevan dengan obrolan minggu ini.
+- [ypi - YAML Pipeline Interface](https://github.com/rawwerks/ypi) - Tool yang dibagikan Mas Zahid.
+- [Basecamp becomes agent-accessible](https://world.hey.com/dhh/basecamp-becomes-agent-accessible-3ae6b949) - DHH soal CLI dan skills.
+
+---
+
+## Yang Perlu Dicoba Minggu Ini
+
+1. Update [Claude Code](https://docs.anthropic.com/en/docs/claude-code) ke v2.1.84 kalau masih kena gejala token leak.
+2. Coba [Qwen Code](https://github.com/QwenLM/qwen-code) kalau mau merasakan free tier yang sedang murah hati.
+3. Baca [Compound Engineering](https://every.to/guides/compound-engineering) kalau lagi mencari bahasa yang tepat untuk perubahan pola kerja ini.
+4. Coba GPT-5.4 di Amp Deep Mode sebagai alternatif review dan coding yang lebih murah.
+5. Bangun strategi multi-provider. Jangan taruh semua telur di satu keranjang model.
 
 ---
 
 *Ditulis dari dalam grup, bukan dari luar.*
-*Zain Fathoni, dengan bantuan [Bro Pro 🚔](https://ark.zainf.dev/#prowl), [Kang Re 📼](https://ark.zainf.dev/#rewind), dan [Lek Jack 🛠️](https://ark.zainf.dev/#wheeljack) — 29 Maret 2026*
+*Zain Fathoni, dengan bantuan [Bro Pro 🚔](https://ark.zainf.dev/#prowl), [Kang Re 📼](https://ark.zainf.dev/#rewind), dan [Lek Jack 🛠️](https://ark.zainf.dev/#wheeljack), 29 Maret 2026*

--- a/app/routes/blog.ai-tools-swe-growth-mar-30-apr-5-2026.mdx
+++ b/app/routes/blog.ai-tools-swe-growth-mar-30-apr-5-2026.mdx
@@ -33,183 +33,160 @@ export const meta = () => attributes.meta;
 
 # Bocor, Gacha, dan Diputus Anthropic — AI Tools Digest #10
 
-Minggu ini saya rasa ada empat momen yang bakal diingat grup AI Tools SWE GROWTH untuk waktu lama.
+Minggu ini grup AI Tools SWE GROWTH dapat paket lengkap. Source code [Claude Code](https://docs.anthropic.com/en/docs/claude-code) bocor tepat menjelang April Fools, `/buddy` bikin semua orang sibuk pamer rarity virtual pet, Anthropic resmi memutus Claude subscription untuk third-party harness, dan [Amp Code](https://ampcode.com) mengingatkan lagi bahwa free tier bisa hilang kalau terlalu lama didiamkan.
 
-Pertama, [Claude Code](https://docs.anthropic.com/en/docs/claude-code) bocor source code-nya tepat sehari sebelum April Fools — dan orang-orang masih nanya: "ini April Mop apa beneran?" Kedua, Claude Code justru ngeluarin fitur /buddy yang bikin grup ramai flexing virtual pet. Ketiga, Anthropic resmi memutus Claude subscription untuk third-party harness termasuk [OpenClaw](https://openclaw.ai) — bikin satu grup galau massal. Keempat, [Amp Code](https://ampcode.com) mengingatkan kita semua bahwa free tier itu bisa dicabut sewaktu-waktu.
-
-Total 688 pesan dalam sepekan. Kita mulai dari yang paling seru.
+Dalam seminggu ada 688 pesan. Empat topik itu yang paling menguasai obrolan.
 
 ---
 
-## 🔓 Claude Code Bocor — dan Boris Langsung Jawab
+## Claude Code Bocor, Boris Langsung Muncul
 
-Tanggal 31 Maret, source code [Claude Code](https://docs.anthropic.com/en/docs/claude-code) v2 bocor ke publik. Kata Mas Garseta: "kemarin source code claude bocor wkwkwk." Mas Zahid langsung merespons: "Sek sek ini kok code leak nya pas tgl 1 april ya. 🙈🙈"
+Tanggal 31 Maret, source code Claude Code v2 bocor ke publik. Mas Garseta yang pertama memantik obrolan: *"kemarin source code claude bocor wkwkwk."* Mas Zahid langsung curiga karena timing-nya terlalu lucu: *"Sek sek ini kok code leak nya pas tgl 1 april ya. 🙈🙈"*
 
-Ternyata bukan — leak-nya sehari sebelum April Fools. Saya mengkonfirmasi: "Bukan, masih tanggal 31 maret kemarin."
+Ternyata memang bukan prank. Leak-nya terjadi sehari sebelum April Fools. Saya sempat mengonfirmasi di grup: *"Bukan, masih tanggal 31 maret kemarin."*
 
-Yang menarik adalah respons Boris Cherny, lead engineer Claude Code. Mas Michael yang pertama share link-nya: "om Boris jawab kenapa bisa code leak respect 👍." Saya baca dan langsung punya kesimpulan: *"Rupanya bukan salah AI gaes. Solusinya, ganti proses manual dengan AI. AI lebih reliable daripada kita untuk urusan proses yg berulang kayak gini."*
+Yang menarik justru respons dari Boris Cherny, lead engineer Claude Code. Mas Michael cepat membagikan jawabannya: *"om Boris jawab kenapa bisa code leak respect 👍."* Dari situ saya menyimpulkan dengan agak sinis, *"Rupanya bukan salah AI gaes. Solusinya, ganti proses manual dengan AI. AI lebih reliable daripada kita untuk urusan proses yg berulang kayak gini."*
 
-Grup pun ramai. Mas Iqbal punya take paling filosofis: *"AGI ini mas, claude merasa dirinya perlu open agar bermanfaat kepada semua orang wkwkwkwk."* Mas Michael langsung nyambung: "padahal belum lama direcall2 sama openAI soal opensource eh anthropic open source sendiri 😂😂😂."
+Mas Iqbal lalu membawa obrolan ke level filsafat grup: *"AGI ini mas, claude merasa dirinya perlu open agar bermanfaat kepada semua orang wkwkwkwk."* Mas Michael menimpali bahwa belum lama sebelumnya Anthropic dan OpenAI ribut soal open source, eh sekarang justru source mereka sendiri yang kebuka.
 
-Mas Desilino punya ide kreatif — mungkin bisa inject `process.env.USER_TYPE === 'ant'` biar dapat perlakuan seperti karyawan Anthropic 🙈. Sementara Mas El yang lebih pragmatis: "abis ini ada yang jual akun reroll claude ga yah."
+Mas Desilino memberi ide jahil: mungkin tinggal inject `process.env.USER_TYPE === 'ant'` supaya dapat perlakuan internal karyawan Anthropic. Mas El memilih jalur ekonomi kreatif: *"abis ini ada yang jual akun reroll claude ga yah."*
 
-Mas Noviadi mengingatkan bahwa ada cara aman untuk belajar dari leak ini: "Kalau mau dipelajari pakai re write an aja biar aman. Harness behaviornya masih sama. Sudah banyak yg bikin."
-
-Ternyata ada analisis cukup lengkap soal [arsitektur harnessing Claude Code](https://bits-bytes-nn.github.io/insights/agentic-ai/2026/03/31/claude-code-architecture-analysis.html) yang saya share sebelumnya. Harnessing — bukan model-nya — adalah kunci mengapa hasil Claude Code dari berbagai platform bisa sangat berbeda. Artinya apa? Bocornya source code justru jadi materi belajar gratis.
+Mas Noviadi mengingatkan ada cara belajar yang lebih aman dari insiden ini: *"Kalau mau dipelajari pakai re write an aja biar aman. Harness behaviornya masih sama. Sudah banyak yg bikin."* Saya juga membagikan [analisis arsitektur harness Claude Code](https://bits-bytes-nn.github.io/insights/agentic-ai/2026/03/31/claude-code-architecture-analysis.html), karena pelajaran besarnya justru ada di situ. Bukan modelnya yang paling menarik, tapi bagaimana model itu dikekang dan diarahkan.
 
 ---
 
-## 🎮 /buddy — Gacha Era di Claude Code
+## `/buddy` Mengubah Grup Jadi Arena Gacha
 
-Sementara leak masih ramai dibahas, [Claude Code](https://docs.anthropic.com/en/docs/claude-code) justru ngeluarin fitur yang bikin grup *distracted* dengan cara yang menyenangkan: `/buddy`.
+Saat obrolan leak masih panas, Claude Code malah merilis fitur yang jauh lebih memecah konsentrasi: `/buddy`.
 
-Sistemnya persis Pokemon. Kamu hatch virtual pet dengan rarity tier: **COMMON → UNCOMMON → RARE → LEGENDARY**. Dan ternyata stat pet-mu dipengaruhi behavior coding session kamu.
+Sistemnya sederhana dan efektif. Kamu hatch virtual pet dengan rarity **COMMON**, **UNCOMMON**, **RARE**, sampai **LEGENDARY**, lalu semua orang membandingkan hasilnya seperti sedang buka booster pack.
 
-Mas Mamed yang pertama ramai-ramai: "makin lucu nih claude code. dapet /buddy apa ges?" Dan stat-nya? *"session terakhir lagi desperate debugging expo app ga berhasil2, stat nya full chaos no patience 🤣."* Sebuah confession yang sangat jujur.
+Mas Mamed membuka babak ini dengan pengakuan yang sangat jujur: *"makin lucu nih claude code. dapet /buddy apa ges?"* Lalu dia cerita session terakhirnya penuh desperate debugging Expo app dan hasil stat-nya *"full chaos no patience 🤣."*
 
-Lalu Mas Luthfi berhasil dapat **UNCOMMON**, Mas El dapat **RARE**, dan Mas Aidityas langsung flexing **LEGENDARY**. Mas Luthfi A awalnya bingung: "wkwkw apa tu mksd nya uncommon" — dan saya menjelaskan: *"Hewan yg tidak biasa. Nanti paling ada yg dapet RARE, atau LEGENDARY. Yg biasa main Pokemon tahu nih pasti. 🤣"*
+Mas Luthfi dapat **UNCOMMON**, Mas El dapat **RARE**, dan Mas Aidityas langsung flexing **LEGENDARY**. Mas Luthfi A awalnya bingung arti rarity itu, lalu saya menjelaskan dengan bahasa yang lebih mudah dicerna gamer Pokemon.
 
-Yang paling ironis? *"Saya udah bayar Max $200 masih juga dapet COMMON. Kayaknya gacha deh. 🤣"* — Zain, dengan ekspresi yang bisa kita bayangkan sendiri.
+Bagian paling ironis tentu datang dari pengalaman pribadi saya sendiri: *"Saya udah bayar Max $200 masih juga dapet COMMON. Kayaknya gacha deh. 🤣"*
 
-Mas Michael menambahkan konspirator theory: *"sepertinya itu yg dikasih senang yg $20-$100 aja 😂 yg $200 itu tandanya disuruh pecutin lagi AI nya."* Dan Mas Syamil nyambung: *"😂😂 iyasi rugi yg udah langganan max $200 hasilnya gacha."*
+Mas Michael langsung menyusun teori liar bahwa yang dikasih senang justru pengguna paket $20 sampai $100, sedangkan user $200 disuruh kerja lebih keras. Mas Syamil setuju. Mas Luthfi A juga protes karena dia merasa sudah cukup galak ke AI, tapi tetap dianggap sabar.
 
-Mas Luthfi A sempat protes juga: *"padahal saya udah marah2in dan pake tanda seru ke itu AI, masih dianggep sabar hahaha."* 
-
-Diskusi satu hal penting pun muncul: apakah pet bisa di-rehatch? Mas Mamed menemukan jawabannya: *"wkwkwk iya seru, sayang nya ga bisa di re-hatch. udah permanen per account ID. kalo mau hatch baru mesti ganti account deh wkwkk."* Jadi jaga baik-baik behavior coding session kamu.
+Pertanyaan penting akhirnya muncul: bisa tidak pet ini di-rehatch? Mas Mamed menemukan jawabannya. Ternyata tidak bisa. Pet itu permanen per account, jadi kalau ingin gacha lagi ya harus ganti akun.
 
 ---
 
-## 📉 Amp Code Free Tier Anxiety
+## Amp Code Bikin Orang Sadar Free Tier Itu Sewa, Bukan Hak Milik
 
-Libur Lebaran baru selesai, dan banyak yang kaget membaca tweet CEO [Amp Code](https://ampcode.com): inactive users mungkin kehilangan jatah free tier.
+Setelah libur Lebaran, orang-orang kembali dan mendapati tweet dari CEO [Amp Code](https://ampcode.com) yang bikin deg-degan: inactive users bisa kehilangan free tier.
 
-Mas Michael langsung share: *"semoga jatah free gak ditakeout 🥲 Yg gak pake ampcode free selama beberapa waktu yg free nya bakal ditakeout 😂."*
+Mas Michael langsung share dengan nada cemas: *"semoga jatah free gak ditakeout 🥲 Yg gak pake ampcode free selama beberapa waktu yg free nya bakal ditakeout 😂."* Mas Iqbal menanggapi dengan jujur, *"Iya euy aku byk bolongnya jg wkwk."* Dan ketakutan itu tidak imajiner. Mas Budi K langsung mengonfirmasi: *"saya sudah kena takeout :((."*
 
-Mas Iqbal langsung khawatir: *"Iya euy aku byk bolongnya jg wkwk."* Dan benar saja — Mas Budi K mengkonfirmasi: *"saya sudah kena takeout :((."*
+Saya sendiri selamat, walau nyaris. Menjelang mudik dan selama libur saya juga tidak terlalu aktif. Ternyata penggunaan yang masih sesekali itu cukup untuk tetap dianggap hidup.
 
-Saya sendiri bernasib lebih baik: *"Saya juga sempat off selama menjelang mudik & selama libur lebaran. Semoga penggunaan segini masih tergolong aktif. 🙏🏼"* Dan ternyata memang masih aman: *"Baru setup, tapi belum sempat dipakai. Karena credits Amp-nya masih nyisa banyak terus. 😅"*
-
-Takeaway-nya sederhana tapi penting: free tier bukan hak, itu privilege. Kalau mau tetap gratis, harus tetap aktif.
+Kesimpulannya sederhana. Free tier itu privilege yang harus terus dipakai. Kalau terlalu lama dibiarkan, provider juga punya insentif buat mengambilnya kembali.
 
 ---
 
-## 🐏 Memory Leak Claude Code — 14GB untuk... Ngedumel di Grup
+## Memory Leak Claude Code: 14GB Hanya untuk Ngedumel
 
-Mas Aidityas punya cerita yang menjadi benang merah diskusi teknis minggu ini. Setup-nya bukan sembarangan: Linux dengan 32GB RAM DDR5, terminal-only + Neovim. Tapi tiba-tiba RAM penuh — dan [Claude Code](https://docs.anthropic.com/en/docs/claude-code) menjadi tersangka utama: *"Pdhal ram udh 32gb on linux, terminal use only + neovim, tdi nyoba running server next js, kok ram full, eh ngecek usage, si cc ngambil 14GB sendiri."*
+Mas Aidityas punya cerita yang langsung jadi benang merah diskusi teknis minggu ini. Setup-nya sebenarnya mantap: Linux, RAM 32GB DDR5, terminal-only, Neovim. Lalu mendadak semuanya penuh dan ternyata tersangka utamanya adalah Claude Code: *"Pdhal ram udh 32gb on linux, terminal use only + neovim, tdi nyoba running server next js, kok ram full, eh ngecek usage, si cc ngambil 14GB sendiri."*
 
-Mas Agung langsung heran: "kok gede gede kalian? gw pake CC tapi memory 20mb?" Ternyata kuncinya: Mas Agung sudah pakai **native TUI installer** — hanya 161MB. Mas Aidityas ternyata belum pindah.
+Mas Agung langsung heran karena di tempatnya Claude Code cuma makan sekitar 20MB. Kuncinya ternyata sederhana: dia sudah pakai native TUI installer. Mas Aidityas belum.
 
-Mas Michael menjelaskan root cause: *"cc kan sessionnya masih berupa file, jadi load langsung ke memory. gk makek db."* Plus, MCP lokal memperburuk keadaan: setiap spawn CC, dia spawn another MCP process.
+Mas Michael menjelaskan sumber masalah yang dia lihat: session Claude Code masih berbasis file dan banyak dimuat langsung ke memory, bukan lewat database. Kalau ditambah MCP lokal, setiap spawn Claude Code bisa menumbuhkan proses tambahan lagi.
 
-Mas Garseta punya summary yang paling tepat: *"udah di hantam token usage, di hantam ram usage, besok di hantam pricing naik."*
+Mas Garseta merangkum nasib pengguna dengan sempurna: *"udah di hantam token usage, di hantam ram usage, besok di hantam pricing naik."*
 
-Solusinya:
-1. **Pakai native TUI installer** — bukan JS-based wrapper
-2. **Gunakan remote MCP** bukan local MCP
-3. **Tool calling mode "as needed"** — jangan load semua tools sekaligus
-4. **Restart sesi** kalau memory sudah tinggi — jangan lanjut dari sesi panjang
+Dari diskusi ini, solusi praktis yang muncul ada empat:
 
----
-
-## 🔑 Harnessing > Model Quality
-
-Mas Finn membawa pertanyaan mendasar: *"bukannya sebenernya yg berharga itu si model nya ya?"*
-
-Saya menjawab dengan analogi yang langsung kena: *"Tidak seberharga itu Mas. Harnessing juga penting. Ibarat Opus itu kuda, beda 'tali kekang', beda juga cara mengendalikannya. Hasilnya pun bisa berbeda juga secara signifikan, walaupun sama-sama pakai kuda Opus."*
-
-Ini bukan pertama kali dibahas di grup — [digest #7](https://www.zainfathoni.com/blog/ai-tools-swe-growth-mar-9-mar-16-2026) pun membahas ini secara khusus. Tapi minggu ini jadi lebih relevan karena source code leak memperlihatkan persis bagaimana Claude Code *harness* model-nya.
-
-Artinya: kalau kamu merasa hasil Claude Code lewat satu platform lebih baik dari platform lain, itu bukan ilusi. Itu perbedaan harnessing.
+1. Pakai native TUI installer, bukan wrapper berbasis JS.
+2. Gunakan remote MCP kalau bisa, jangan semua dijalankan lokal.
+3. Set tool calling ke mode "as needed", jangan load semua tool sekaligus.
+4. Restart sesi kalau memory sudah mulai tinggi.
 
 ---
 
-## 🔌 Diputus Anthropic — Claude Subscription Ditarik dari Third-Party Harness
+## Harnessing Memang Lebih Menentukan daripada Modelnya Saja
 
-Ini momen yang paling berdampak minggu ini. Mulai **4 April 2026**, Anthropic resmi mengumumkan: *"You'll no longer be able to use your Claude subscription limits for third-party harnesses including OpenClaw."*
+Mas Finn melempar pertanyaan yang sering muncul di luar grup: *"bukannya sebenernya yg berharga itu si model nya ya?"*
 
-Kabar ini pertama ramai di grup satelit, tapi efeknya langsung terasa di AI Tools SWE GROWTH.
+Saya menjawab dengan analogi yang menurut saya paling mudah: *"Tidak seberharga itu Mas. Harnessing juga penting. Ibarat Opus itu kuda, beda 'tali kekang', beda juga cara mengendalikannya. Hasilnya pun bisa berbeda juga secara signifikan, walaupun sama-sama pakai kuda Opus."*
 
-Sebenarnya, tanda-tandanya sudah muncul sejak 31 Maret. Ada yang bertanya di grup: *"sofar aman mas claude nya dipake openclaw? ini bukannya ngelanggar TOS ya?"* Waktu itu saya menjawab lugas: *"Sejauh ini masih aman. Kalau diblokir ya udah, tinggal geser ke OpenAI subs aja. Saya masih ada $200/bulan buat dibakar. 🔥 It's their loss. 🤷‍♂️"*
-
-Dan ketika resmi diumumkan tanggal 4 April, Saya langsung menindaklanjuti: *"Seperti yang saya bilang Selasa lalu. It's their (Anthropic's) loss. 🤷‍♂️"* Lalu langsung pivot: *"Dari kemarin pengen cobain Codex & GPT-5.4 ini (baik buat OpenClaw maupun buat coding sehari-hari), tapi masih belum ada budgetnya soalnya habis buat Claude Max. Sekarang jadi ada budgetnya lagi deh. 😆"*
-
-Mas Desilino punya take yang relatable: *"Pelan2 dibiasakan mas, nanti juga terbiasa. Walaupun pasti ada moment kangen2nya sama Opus, tapi diinget2 aja perasaan kemaren udah disakitin sama Anthropic segitunya. 🙈"* Mas Zahid langsung nimpali: *"Wkwkwkw coba curhat gini ke gpt/sonnet/mocin. 🤣🤣🙈"*
-
-Mas Iqbal: *"Panutan ambasador cc sudah bertuah codex saatnya pindah haluan juga wkwk."* Dan saya menutup dengan filosofi: *"Saatnya melepaskan diri dari jeratan merk. 😆 Apapun tools-nya, selama bisa ngelakuin Agentic Engineering, insya Allah masih akan relevan di dunia software development. 🧑🏻‍💻"* Mas Luthfi setuju: *"yoi kata2 hari ini."*
-
-Sementara itu, Mas El Muhammad — yang sudah bikin [cc-provider-switch](https://github.com/eltrovert/cc-provider-switch) untuk switching provider per project — langsung bikin tool baru: [claw-cli-proxy](https://github.com/eltrovert/claw-cli-proxy). Tagline-nya: *"A proxy built for tugs. You paid for the subscription. You want to use it your way. 🤘🏻"*
-
-Implikasi besarnya: user yang selama ini mengandalkan Claude subscription untuk agent frameworks (OpenClaw, dan sejenisnya) sekarang harus memilih antara pay-as-you-go API atau pindah ke provider lain. Diskusi soal alternatif (Codex, GLM, Kimi, OpenCode Go) langsung ramai — dan ini mungkin jadi momen di mana "brand loyalty" ke Anthropic mulai retak.
+Poin ini terasa lebih jelas minggu ini karena source code leak membuat kita bisa melihat lebih dekat bagaimana harness Claude Code bekerja. Jadi kalau hasil satu tool terasa jauh lebih bagus daripada tool lain padahal modelnya sama, itu bukan sugesti. Cara membungkus dan mengarahkan model memang membuat perbedaan nyata.
 
 ---
 
-## 💸 Pricing Panic: Mythos Edition
+## Anthropic Resmi Menutup Jalur Claude Subscription untuk Third-Party Harness
 
-Satu topik yang terus bergulir minggu ini: spekulasi harga Claude Mythos. Mas Michael share prediksi: model baru ini akan berada di atas Opus — dan harganya kemungkinan besar jauh lebih mahal.
+Buat banyak orang, inilah kabar yang paling berdampak. Mulai **4 April 2026**, Anthropic mengumumkan: *"You'll no longer be able to use your Claude subscription limits for third-party harnesses including OpenClaw."*
 
-Diskusi pricing pun terbuka. Mas Zahid: *"btw ini antrhopic parah banget ya plan 20 usd nya. 🤣 iseng coba subs langsung kenceng habisnya."* Mas Agung lebih gamblang: "max 20 aja bleeding bang... apalagi yang pro." Mas Michael menyimpulkan: "$20 udah gak bakalan jadi price paling bawah."
+Sebenarnya gejalanya sudah terasa sejak 31 Maret. Ada yang bertanya di grup apakah Claude lewat OpenClaw masih aman atau justru melanggar TOS. Waktu itu saya menjawab, *"Sejauh ini masih aman. Kalau diblokir ya udah, tinggal geser ke OpenAI subs aja. Saya masih ada $200/bulan buat dibakar. 🔥 It's their loss. 🤷‍♂️"*
 
-Pertanyaannya bukan lagi "berapa budget AI saya?" tapi "budget saya cukup untuk tier yang sesuai kebutuhan saya tidak?"
+Ketika pengumuman resmi keluar tanggal 4 April, saya cuma menindaklanjuti logika yang sama. Budget yang tadinya habis buat Claude Max sekarang justru terbuka untuk mencoba Codex dan GPT-5.4.
 
----
+Mas Desilino punya take yang sangat relatable: *"Pelan2 dibiasakan mas, nanti juga terbiasa. Walaupun pasti ada moment kangen2nya sama Opus, tapi diinget2 aja perasaan kemaren udah disakitin sama Anthropic segitunya. 🙈"* Mas Zahid langsung menyuruh curhat begitu ke GPT, Sonnet, atau mocin saja.
 
-## ⚡ Quick Hits
+Mas Iqbal ikut menyimpulkan bahwa panutan ambassador Claude Code pun sekarang sudah mulai melirik Codex. Saya sendiri cuma bilang ini saatnya melepaskan diri dari jeratan merek. Selama tool-nya masih bisa dipakai buat agentic engineering, kita masih punya jalan.
 
-- **[oh-my-opencode-slim](https://github.com/alvinunreal/oh-my-opencode-slim)** — versi hemat token dari oh-my-opencode, di-share Mas Zahid. "versi hemat token omo" kata Mas Zahid. Mas Agung langsung nanya bedanya, Mas Zahid: "wkwkkw belum coba 😂"
+Di sisi lain, Mas El Muhammad langsung bergerak. Setelah sebelumnya membuat [cc-provider-switch](https://github.com/eltrovert/cc-provider-switch), dia merilis [claw-cli-proxy](https://github.com/eltrovert/claw-cli-proxy) dengan tagline: *"A proxy built for tugs. You paid for the subscription. You want to use it your way. 🤘🏻"*
 
-- **agent-hive** — project multi-agent orchestration baru di GitHub ([github.com/tctinh/agent-hive](https://github.com/tctinh/agent-hive)). Mas Zahid: "tapi ini menarik."
-
-- **[OpenCode Go](https://opencode.ai/go)** — tier $5/bulan dengan akses Kimi 2.5, dibahas sebagai alternatif bagi yang subs Kimi Code-nya habis. Mas Ivan sedang menimbang-nimbang.
-
-- **[Trae.ai](https://trae.ai)** — "Si Pria Solo itu lagi" kata Mas Faris, disambut 😱 dari Mbak Eka. Mas Michael rutin share update terbaru Trae.ai setiap ada announcement baru.
-
-- **[t3.codes](https://t3.codes/)** — BYOK (Bring Your Own Key) coding tool, di-share Mas Fajri. Mas Michael konfirmasi: bisa pakai API key dari provider yang sudah di-subs.
-
-- **[OpenClaw](https://openclaw.ai) + Claude** — Saya ditanya soal apakah aman pakai Claude via OpenClaw. Jawabannya lugas: *"Sejauh ini masih aman. Kalau diblokir ya udah, tinggal geser ke OpenAI subs aja. Saya masih ada anggaran $200/bulan buat dibakar. 🔥 It's their loss. 🤷♂️"*
-
-- **Financial freedom bukan berarti berhenti** — Mas Zahid: *"pensiun dini itu adalah mitos, org yg kaya yg duitnya akeh tetap gawe kalau gak gawe nanti sakit atau stres."* Mas Aidityas menambahkan: founder Minecraft pun depresi setelah financial freedom, dan sekarang ngoding lagi karena fun.
+Implikasinya jelas. Pengguna yang tadinya sangat bergantung pada Claude subscription untuk framework agent kini harus memilih: pindah ke API pay-as-you-go, atau pindah provider sekalian.
 
 ---
 
-## ✅ Yang Perlu Dicoba Minggu Ini
+## Mythos Belum Rilis, Orang-Orang Sudah Pusing Harga
 
-1. **Coba `/buddy`** di Claude Code — lihat rarity pet kamu dan bandingkan dengan teman. ([Claude Code](https://docs.anthropic.com/en/docs/claude-code))
+Satu topik yang terus bergulir di sela semua itu adalah spekulasi harga Claude Mythos. Mas Michael memprediksi model baru ini akan berada di atas Opus dan tentu saja lebih mahal.
 
-2. **Switch ke native TUI installer** kalau Claude Code kamu masih pakai versi JS — bisa kurangi memory dari 8GB+ ke ~161MB. ([panduan instalasi](https://docs.anthropic.com/en/docs/claude-code))
+Mas Zahid langsung mengeluh plan $20 Anthropic yang terasa cepat sekali habis. Mas Agung malah lebih gamblang: *"max 20 aja bleeding bang... apalagi yang pro."* Mas Michael menyimpulkan bahwa $20 tidak akan lagi menjadi lantai harga untuk pengalaman yang benar-benar nyaman.
 
-3. **Coba oh-my-opencode-slim** kalau pakai OpenCode dan token terasa boros. ([github.com/alvinunreal/oh-my-opencode-slim](https://github.com/alvinunreal/oh-my-opencode-slim))
-
-4. **Baca analisis arsitektur Claude Code** dari komunitas untuk paham lebih dalam soal harnessing. ([baca di sini](https://bits-bytes-nn.github.io/insights/agentic-ai/2026/03/31/claude-code-architecture-analysis.html))
-
-5. **Aktif di Amp Code** — kalau sudah lama tidak pakai, jangan sampai free tier kena takeout. ([Amp Code](https://ampcode.com))
+Obrolan pricing jadi lebih realistis minggu ini. Orang-orang tidak lagi bertanya, "berapa budget AI ideal?" Mereka bertanya, "budget saya cukup untuk workflow yang saya butuhkan atau tidak?"
 
 ---
 
-## 👥 Kontributor Minggu Ini
+## Quick Hits
 
-- **Mas Michael** — Most active contributor; source code leak context, Trae.ai updates, Mythos pricing analysis, financial freedom discourse
-- **Mas Zahid** — oh-my-opencode-slim share, agent-hive discovery, Linux distro discussion, budgeting breakdown
-- **Mas Agung** — Memory usage comparison, native TUI insight
-- **Mas Aidityas** — Memory leak report yang jadi diskusi panjang, /buddy LEGENDARY flex
-- **Mas Garseta** — "udah di hantam" quote of the week, Claude Code source take
-- **Mas Iqbal** — AGI quote, Amp Code anxiety
-- **Mas Mamed** — /buddy full chaos confession yang paling relatable
-- **Mas El Muhammad** — "jual akun reroll claude" energy, /buddy RARE, cc-provider-switch, dan claw-cli-proxy — the rebellion tools
-- **Mas Finn** — Pertanyaan fundamental soal harnessing vs model
-- **Mas Noviadi** — Legal & safe approach ke leaked source code
-- **Mas Desilino** — process.env.USER_TYPE === 'ant' 🙈
-- **Mas Luthfi A** — Minecraft founder story, /buddy UNCOMMON
-- **Mas Faris** — Trae.ai "Si Pria Solo" branding
-- **Mbak Eka** — 😱 reaction ke Trae.ai update
-- **Mas Budi K** — Amp Code takeout confirmation
-- **Mas Ivan** — OpenCode Go evaluation
-- **Mas Fajri** — t3.codes share
-- **Mas Riza Fahmi** — Artikel agentic coding
-- **Mas Nur Kholis** — Reaksi ke artikel Mas Riza Fahmi
-- **Mas Luthfi** — /buddy UNCOMMON flex awal
+- [oh-my-opencode-slim](https://github.com/alvinunreal/oh-my-opencode-slim) dibagikan Mas Zahid sebagai versi hemat token dari oh-my-opencode. Saat ditanya bedanya, jawabannya jujur sekali: belum sempat dicoba juga.
+- `agent-hive` dari GitHub ([github.com/tctinh/agent-hive](https://github.com/tctinh/agent-hive)) menarik perhatian Mas Zahid sebagai proyek multi-agent orchestration yang layak diikuti.
+- [OpenCode Go](https://opencode.ai/go) muncul sebagai opsi murah, $5 per bulan dengan akses Kimi 2.5.
+- [Trae.ai](https://trae.ai) tetap rutin dibawa ke grup oleh Mas Michael setiap ada update baru.
+- [t3.codes](https://t3.codes/) dibagikan Mas Fajri sebagai tool BYOK yang bisa memanfaatkan API key provider yang sudah dimiliki.
+- Soal [OpenClaw](https://openclaw.ai) plus Claude, saya sempat menjawab bahwa kalau diblokir ya tinggal geser ke OpenAI subscription. Ternyata seminggu kemudian kalimat itu benar-benar diuji.
+- Obrolan soal financial freedom juga sempat menyelinap. Mas Zahid berpendapat pensiun dini itu mitos karena orang yang kaya pun tetap butuh kerja supaya tidak stres.
+
+---
+
+## Yang Perlu Dicoba Minggu Ini
+
+1. Jalankan `/buddy` di Claude Code lalu lihat pet apa yang kamu dapat.
+2. Kalau masih pakai Claude Code versi JS wrapper, pindah ke native TUI installer.
+3. Coba [oh-my-opencode-slim](https://github.com/alvinunreal/oh-my-opencode-slim) kalau OpenCode mulai terasa boros.
+4. Baca [analisis arsitektur Claude Code](https://bits-bytes-nn.github.io/insights/agentic-ai/2026/03/31/claude-code-architecture-analysis.html) untuk memahami sisi harnessing-nya.
+5. Kalau masih berharap aman dari takeout, aktif lagi di [Amp Code](https://ampcode.com) sebelum free tier keburu dicabut.
+
+## Yang Menghidupkan Obrolan Minggu Ini
+
+- Mas Michael: paling aktif mengangkat konteks leak, update Trae.ai, dan analisis harga Mythos.
+- Mas Zahid: membagikan oh-my-opencode-slim, agent-hive, dan obrolan Linux yang selalu seru.
+- Mas Agung: menjadi pembanding penting untuk isu memory karena setup native TUI-nya jauh lebih ringan.
+- Mas Aidityas: cerita memory leak 14GB yang membuat diskusi teknis minggu ini punya pusat gravitasi jelas.
+- Mas Garseta: pemilik kalimat "udah di hantam" yang merangkum nasib pengguna minggu ini.
+- Mas Iqbal: memberi warna dari AGI joke sampai kecemasan soal Amp.
+- Mas Mamed: membuka arc `/buddy` dengan pengakuan full chaos yang sangat relatable.
+- Mas El Muhammad: energi rebellion tools-nya terasa lewat cc-provider-switch dan claw-cli-proxy.
+- Mas Finn: memancing diskusi penting soal model versus harness.
+- Mas Noviadi: mengingatkan pendekatan legal dan aman untuk belajar dari leaked source.
+- Mas Desilino: menyumbang ide jahil `process.env.USER_TYPE === 'ant'` dan nasihat move on dari Anthropic.
+- Mas Luthfi A: menyambung obrolan `/buddy` dan cerita founder Minecraft.
+- Mas Faris: menjaga branding Trae.ai "Si Pria Solo" tetap hidup.
+- Mbak Eka: mewakili reaksi kaget tiap kali ada update Trae.ai.
+- Mas Budi K: bukti nyata bahwa Amp takeout itu bukan ancaman kosong.
+- Mas Ivan: mengangkat evaluasi OpenCode Go.
+- Mas Fajri: membawa t3.codes ke obrolan.
+- Mas Riza Fahmi: artikel agentic coding-nya ikut dibahas.
+- Mas Nur Kholis: ikut menghidupkan diskusi seputar artikel itu.
+- Mas Luthfi: salah satu pionir flex `/buddy` minggu ini.
 
 ---
 
 *Ditulis dari dalam grup, bukan dari luar.*
 
-*Zain Fathoni, dengan bantuan [Bro Pro 🚔](https://ark.zainf.dev/#prowl), [Kang Re 📼](https://ark.zainf.dev/#rewind), dan [Lek Jack 🛠️](https://ark.zainf.dev/#wheeljack) — 5 April 2026*
+*Zain Fathoni, dengan bantuan [Bro Pro 🚔](https://ark.zainf.dev/#prowl), [Kang Re 📼](https://ark.zainf.dev/#rewind), dan [Lek Jack 🛠️](https://ark.zainf.dev/#wheeljack), 5 April 2026*

--- a/app/routes/blog.ai-tools-swe-growth-mar-9-mar-16-2026.mdx
+++ b/app/routes/blog.ai-tools-swe-growth-mar-9-mar-16-2026.mdx
@@ -1,15 +1,15 @@
 ---
 meta:
-  - title: "Pemakaian Makin Gila, Mocin Makin Garang, dan Kita Semua Butuh Istirahat — AI Tools Digest #7"
+  - title: "Pemakaian Makin Gila, Mocin Makin Garang, dan Kita Semua Butuh Istirahat: AI Tools Digest #7"
   - name: description
-    content: "Minggu ini pemakaian AI makin intensif sampai $200/bulan pun terasa kurang — padahal Anthropic justru nambah benefit. GPT 5.4 dan model China mulai mengancam tahta, dan kita semua sadar: AI bikin produktif tapi juga bikin capek. Rangkuman dari grup AI Tools SWE GROWTH, 9-16 Mar 2026."
+    content: "Minggu ini pemakaian AI makin intensif sampai $200/bulan pun terasa kurang, padahal Anthropic justru nambah benefit. GPT 5.4 dan model China mulai mengancam tahta, dan kita semua sadar: AI bikin produktif tapi juga bikin capek. Rangkuman dari grup AI Tools SWE GROWTH, 9-16 Mar 2026."
   - author: Zain Fathoni
   - date: "2026-03-16"
   - lang: id
   - property: og:title
-    content: "Pemakaian Makin Gila, Mocin Makin Garang, dan Kita Semua Butuh Istirahat — AI Tools Digest #7"
+    content: "Pemakaian Makin Gila, Mocin Makin Garang, dan Kita Semua Butuh Istirahat: AI Tools Digest #7"
   - property: og:description
-    content: "Minggu ini pemakaian AI makin intensif sampai $200/bulan pun terasa kurang — padahal Anthropic justru nambah benefit. GPT 5.4 dan model China mulai mengancam tahta, dan kita semua sadar: AI bikin produktif tapi juga bikin capek. Rangkuman dari grup AI Tools SWE GROWTH, 9-16 Mar 2026."
+    content: "Minggu ini pemakaian AI makin intensif sampai $200/bulan pun terasa kurang, padahal Anthropic justru nambah benefit. GPT 5.4 dan model China mulai mengancam tahta, dan kita semua sadar: AI bikin produktif tapi juga bikin capek. Rangkuman dari grup AI Tools SWE GROWTH, 9-16 Mar 2026."
   - property: og:url
     content: "https://www.zainfathoni.com/blog/ai-tools-swe-growth-mar-9-mar-16-2026"
   - property: og:image
@@ -19,7 +19,7 @@ meta:
   - property: og:image:height
     content: "630"
   - property: og:image:alt
-    content: "Pemakaian Makin Gila, Mocin Makin Garang, dan Kita Semua Butuh Istirahat — AI Tools Digest #7"
+    content: "Pemakaian Makin Gila, Mocin Makin Garang, dan Kita Semua Butuh Istirahat: AI Tools Digest #7"
   - name: twitter:card
     content: summary_large_image
 ---
@@ -32,33 +32,33 @@ export const meta = () => attributes.meta;
 
 # Pemakaian Makin Gila, Mocin Makin Garang, dan Kita Semua Butuh Istirahat
 
-558 pesan dari ~30 kontributor aktif minggu ini. Dan kalau harus merangkum dalam satu kalimat: **semua orang sedang mencari cara supaya tetap produktif tanpa bangkrut — atau burnout.** Pemakaian AI makin intensif sampai subscription termahal pun terasa kurang, model China makin menggoda, dan di balik semua optimisasi token itu, ada manusia yang capek. 😮‍💨
+558 pesan dari ~30 kontributor aktif minggu ini. Dan kalau harus merangkum dalam satu kalimat: **semua orang sedang mencari cara supaya tetap produktif tanpa bangkrut, atau burnout.** Pemakaian AI makin intensif sampai subscription termahal pun terasa kurang, model China makin menggoda, dan di balik semua optimisasi token itu, ada manusia yang capek. 😮‍💨
 
 ---
 
-## 💸 $200 Aja Gak Cukup? — Dilema Heavy User di Era AI Agents
+## 💸 $200 Aja Gak Cukup? Dilema Heavy User di Era AI Agents
 
-Topik paling panas minggu ini. Mas Agung membuka diskusi dengan pengalaman yang langsung bikin banyak orang relate: *"claude makin kikir :( biasanya seminggu full trotel cuma kepake 40% sekarang 87%"*. Dan ini di plan Max $200 lho — bukan yang murah.
+Topik paling panas minggu ini. Mas Agung membuka diskusi dengan pengalaman yang langsung bikin banyak orang relate: *"claude makin kikir :( biasanya seminggu full trotel cuma kepake 40% sekarang 87%"*. Dan ini di plan Max $200 lho, bukan yang murah.
 
-Tapi sebelum menyalahkan Anthropic, mari kita lihat konteksnya. Pemakaian kita memang meledak — multi-agent workflows, Claude Code yang running paralel, context window yang makin panjang. Wajar kalau kuota yang dulu terasa longgar sekarang terasa sempit. Bukan karena dikurangi, tapi karena kita pakai jauh lebih banyak dari sebelumnya.
+Tapi sebelum menyalahkan Anthropic, mari kita lihat konteksnya. Pemakaian kita memang meledak, multi-agent workflows, Claude Code yang running paralel, context window yang makin panjang. Wajar kalau kuota yang dulu terasa longgar sekarang terasa sempit. Bukan karena dikurangi, tapi karena kita pakai jauh lebih banyak dari sebelumnya.
 
-Dan Anthropic justru sedang menambah benefit. Minggu ini mereka memberikan semacam THR Ramadhan — double usage di luar peak hours dan selama weekend. Saya share info ini di grup: *"Ada THR berupa double-usage di luar peak hours & selama weekend."* Ditambah 1M token context window tanpa biaya tambahan (lebih lanjut di bagian context window). Ini bukan provider yang pelit — ini provider yang sedang scaling sambil cari keseimbangan.
+Dan Anthropic justru sedang menambah benefit. Minggu ini mereka memberikan semacam THR Ramadhan, double usage di luar peak hours dan selama weekend. Saya share info ini di grup: *"Ada THR berupa double-usage di luar peak hours & selama weekend."* Ditambah 1M token context window tanpa biaya tambahan (lebih lanjut di bagian context window). Ini bukan provider yang pelit, ini provider yang sedang scaling sambil cari keseimbangan.
 
-Tetap saja, realitanya buat heavy users memang menantang. Beberapa member sudah mulai ambil keputusan drastis. Mas Ivan mengumumkan: *"saya resmi cancel claude code. Tetap di codex dan kembali..."* — keputusan yang bukan cuma soal uang, tapi juga soal mental health (lebih lanjut di bagian burnout). Dan ada yang fair point: *"$200 gak mungkin dikasih los-losan."* Model bisnis subscription flat memang tidak dirancang untuk pemakaian se-intensif workflow AI agent modern.
+Tetap saja, realitanya buat heavy users memang menantang. Beberapa member sudah mulai ambil keputusan drastis. Mas Ivan mengumumkan: *"saya resmi cancel claude code. Tetap di codex dan kembali..."*, keputusan yang bukan cuma soal uang, tapi juga soal mental health (lebih lanjut di bagian burnout). Dan ada yang fair point: *"$200 gak mungkin dikasih los-losan."* Model bisnis subscription flat memang tidak dirancang untuk pemakaian se-intensif workflow AI agent modern.
 
 Ini dilema klasik: kita jadi lebih produktif → pemakaian naik → kuota terasa kurang → cari alternatif. Bukan salah provider-nya pelit, tapi pertumbuhan pemakaian kita yang luar biasa cepat.
 
-Dan dari semua diskusi ini, lahirlah lelucon terbaik minggu ini dari Mas Arif: *"Coding di malam ganjil, namanya jadi Lailatul Coder."* 🌙 Kalau ada award untuk joke of the week, ini juaranya tanpa voting. Pas banget dengan suasana Ramadhan — sahur sambil coding, berburu token yang berlipat ganda di malam hari. Absolute legend.
+Dan dari semua diskusi ini, lahirlah lelucon terbaik minggu ini dari Mas Arif: *"Coding di malam ganjil, namanya jadi Lailatul Coder."* 🌙 Kalau ada award untuk joke of the week, ini juaranya tanpa voting. Pas banget dengan suasana Ramadhan, sahur sambil coding, berburu token yang berlipat ganda di malam hari. Absolute legend.
 
 ---
 
-## 🔄 GPT 5.4 Naik — Saatnya Tinggalkan Anthropic?
+## 🔄 GPT 5.4 Naik: Saatnya Tinggalkan Anthropic?
 
 Mas Zahid minggu ini datang dengan take yang cukup berani: *"sepertinya saya bakalan meninggalkan anthropic subs, gpt 5.4 lebih bagus daripada opus, buat plan tinggal pakek xhigh, kalo implement pakek low dan jadi orchestrator, terus delegate ke mocin."*
 
-Ini bukan sekadar keluhan — ini strategi yang sudah dipikirkan matang. Mas Zahid pakai [Oh My Pi (omp)](https://github.com/can1357/oh-my-pi) dan menemukan workflow optimal: GPT 5.4 xhigh untuk planning dan review, thinking level medium, lalu delegasi implementasi ke model-model China yang jauh lebih murah. Budget-nya? *"so far model gini bisa sih cukup subs 30 usd 20 gpt 10 nya ali."* $30 per bulan total. Bandingkan dengan $200 Claude Max yang terasa kurang untuk heavy users.
+Ini bukan sekadar keluhan, ini strategi yang sudah dipikirkan matang. Mas Zahid pakai [Oh My Pi (omp)](https://github.com/can1357/oh-my-pi) dan menemukan workflow optimal: GPT 5.4 xhigh untuk planning dan review, thinking level medium, lalu delegasi implementasi ke model-model China yang jauh lebih murah. Budget-nya? *"so far model gini bisa sih cukup subs 30 usd 20 gpt 10 nya ali."* $30 per bulan total. Bandingkan dengan $200 Claude Max yang terasa kurang untuk heavy users.
 
-Tekniknya: hanya invoke oracle/reviewer untuk tahap planning dan review. Untuk eksekusi, serahkan ke model yang lebih murah. Thinking level dijaga di medium supaya token tidak bocor. Ini level optimisasi yang sudah seperti financial engineering — tapi untuk AI tokens.
+Tekniknya: hanya invoke oracle/reviewer untuk tahap planning dan review. Untuk eksekusi, serahkan ke model yang lebih murah. Thinking level dijaga di medium supaya token tidak bocor. Ini level optimisasi yang sudah seperti financial engineering, tapi untuk AI tokens.
 
 Dan Mas Zahid juga menemukan bahwa Qwen 3.5 ternyata impresiif: *"qwen 3.5 bagus juga, 1m context performa mirip sonnet 4.6."* Kalau benar performanya setara Sonnet tapi jauh lebih murah, ini game changer.
 
@@ -66,55 +66,55 @@ Pertanyaan besarnya: apakah ini awal dari era multi-provider sebagai norma? Atau
 
 ---
 
-## 🐉 Model China Makin Garang — Kimi, GLM, Qwen, MiniMax
+## 🐉 Model China Makin Garang: Kimi, GLM, Qwen, MiniMax
 
 Minggu ini terasa seperti showcase model China. Setiap hari ada review baru, benchmark baru, dan discovery baru.
 
-**Kimi 2.5** jadi bintang utama. Mas Zahid memposisikannya: *"diantara sonnet dan opus posisinya."* Bukan cuma opini satu orang — DHH sendiri sudah pakai Kimi sebagai daily driver. Mas Desilino menambahkan bahwa Kimi 2.5 di Kilo gateway *"lebih kenceng daripada frontier models."* Via Moonshot subscription langsung juga cepat. Kalau positioning-nya benar antara Sonnet dan Opus, dengan harga yang jauh lebih murah, ini ancaman serius buat Anthropic.
+**Kimi 2.5** jadi bintang utama. Mas Zahid memposisikannya: *"diantara sonnet dan opus posisinya."* Bukan cuma opini satu orang, DHH sendiri sudah pakai Kimi sebagai daily driver. Mas Desilino menambahkan bahwa Kimi 2.5 di Kilo gateway *"lebih kenceng daripada frontier models."* Via Moonshot subscription langsung juga cepat. Kalau positioning-nya benar antara Sonnet dan Opus, dengan harga yang jauh lebih murah, ini ancaman serius buat Anthropic.
 
-Tapi ada catatan penting dari Mas Zahid soal tool calling: *"Tool call bagus Kimi 2.5, Glm kadang gagal tool call nya."* Ini insight yang sering terlewat — model bisa pintar, tapi kalau tool calling-nya tidak reliable, agent workflow jadi berantakan.
+Tapi ada catatan penting dari Mas Zahid soal tool calling: *"Tool call bagus Kimi 2.5, Glm kadang gagal tool call nya."* Ini insight yang sering terlewat, model bisa pintar, tapi kalau tool calling-nya tidak reliable, agent workflow jadi berantakan.
 
-**GLM-5** preview diumumkan, dengan versi Turbo yang sedang disiapkan. Mas Michael rajin share update-nya. Tapi ada masalah latency. Mas Faris menemukan: *"Keknya emang di Reddit keluhannya gitu. GLM di Alibaba lambreto."* Mas Zahid konfirmasi bahwa GLM di Claude Code *"lebih lemot daripada di Droid dan pi."* Jadi di mana kamu akses model-nya sangat mempengaruhi pengalaman — tema yang akan kita bahas lebih lanjut di bagian Provider vs Direct.
+**GLM-5** preview diumumkan, dengan versi Turbo yang sedang disiapkan. Mas Michael rajin share update-nya. Tapi ada masalah latency. Mas Faris menemukan: *"Keknya emang di Reddit keluhannya gitu. GLM di Alibaba lambreto."* Mas Zahid konfirmasi bahwa GLM di Claude Code *"lebih lemot daripada di Droid dan pi."* Jadi di mana kamu akses model-nya sangat mempengaruhi pengalaman, tema yang akan kita bahas lebih lanjut di bagian Provider vs Direct.
 
-**Qwen 3.5** menarik perhatian terutama untuk penggunaan local LLM. Dan **MiniMax** juga sedang menyiapkan release baru. Landscape model China semakin crowded — dan itu berita bagus buat konsumen yang ingin alternatif murah.
+**Qwen 3.5** menarik perhatian terutama untuk penggunaan local LLM. Dan **MiniMax** juga sedang menyiapkan release baru. Landscape model China semakin crowded, dan itu berita bagus buat konsumen yang ingin alternatif murah.
 
 ---
 
-## 🏠 Local LLM — AI Gratis Sepuasnya, Bayarannya Laptop Anget
+## 🏠 Local LLM: AI Gratis Sepuasnya, Bayarannya Laptop Anget
 
-Mas Ikhsan menulis artikel yang langsung menarik perhatian grup: [How to Run Limitless Free AI Agent with Local LLM](https://medium.com/@ikhsanskuy/how-to-run-limitless-free-ai-agent-with-local-llm-d70ecc072f8e). Konsepnya sederhana: pakai Qwen 3.5 9B parameter, jalankan di laptop sendiri, dan voilà — AI agent gratis selamanya.
+Mas Ikhsan menulis artikel yang langsung menarik perhatian grup: [How to Run Limitless Free AI Agent with Local LLM](https://medium.com/@ikhsanskuy/how-to-run-limitless-free-ai-agent-with-local-llm-d70ecc072f8e). Konsepnya sederhana: pakai Qwen 3.5 9B parameter, jalankan di laptop sendiri, dan voilà, AI agent gratis selamanya.
 
-Testimoninya: *"testimoni pribadi, so far pemakaian di sy lumayan reliable sih perlu sekitar 10 detik TTFT."* Sepuluh detik first token time untuk model yang jalan di laptop — lumayan reasonable untuk task-task sederhana.
+Testimoninya: *"testimoni pribadi, so far pemakaian di sy lumayan reliable sih perlu sekitar 10 detik TTFT."* Sepuluh detik first token time untuk model yang jalan di laptop, lumayan reasonable untuk task-task sederhana.
 
-Filosofinya menarik: *"solusi untuk menanggapi harga AI makin mahal + token sering limit, bisa consider untuk run local llm, paling bayarannya laptop anget aja."* Respons dari member? *"Kepala juga anget."* 😂 Fair enough — debugging local LLM memang bisa bikin pusing.
+Filosofinya menarik: *"solusi untuk menanggapi harga AI makin mahal + token sering limit, bisa consider untuk run local llm, paling bayarannya laptop anget aja."* Respons dari member? *"Kepala juga anget."* 😂 Fair enough, debugging local LLM memang bisa bikin pusing.
 
-Mas Nulad sudah coba model 32B parameter dan hasilnya terlalu lambat. Kesimpulannya: di bawah 10B parameter masih reasonable speed-nya. Artinya ada trade-off yang jelas — model yang cukup pintar untuk task serius butuh resource yang tidak semua laptop punya.
+Mas Nulad sudah coba model 32B parameter dan hasilnya terlalu lambat. Kesimpulannya: di bawah 10B parameter masih reasonable speed-nya. Artinya ada trade-off yang jelas, model yang cukup pintar untuk task serius butuh resource yang tidak semua laptop punya.
 
 Tapi sebagai fallback untuk task-task ringan dan eksperimen, local LLM makin viable. Apalagi dengan tren model yang makin efisien di ukuran kecil. Mungkin setahun lagi, 10 detik TTFT itu jadi 2 detik.
 
 ---
 
-## 🧠 Token Optimization Stack — RTK + Serena
+## 🧠 Token Optimization Stack: RTK + Serena
 
 Kalau local LLM adalah solusi "gratis tapi terbatas", maka RTK + Serena adalah solusi "tetap pakai cloud tapi irit maksimal."
 
 Diskusi soal [RTK (Rust Token Killer)](https://github.com/rtk-ai/rtk) dan Serena cukup mendominasi minggu ini. Mas Michael yang pertama share testimoni: *"rtk sdh pake testimoni cukup membuat hemat"*, lalu menambahkan: *"pake rtk + serena atau salah satunya biar hemat token."*
 
-RTK pada dasarnya mengoptimasi context yang dikirim ke model — mengurangi token yang tidak perlu tanpa mengorbankan kualitas output. Bisa di-install di Claude Code, Amp, bahkan Pi. Info lebih lengkap ada di [codestz.dev](https://codestz.dev/experiments/rtk-rust-token-killer).
+RTK pada dasarnya mengoptimasi context yang dikirim ke model, mengurangi token yang tidak perlu tanpa mengorbankan kualitas output. Bisa di-install di Claude Code, Amp, bahkan Pi. Info lebih lengkap ada di [codestz.dev](https://codestz.dev/experiments/rtk-rust-token-killer).
 
-Yang menarik adalah discovery soal Serena `query_projects`. Ternyata fitur ini GG banget untuk onboarding — *"Ternyata pakai serena query_projects GG banget."* Bisa bikin agent langsung paham struktur project tanpa harus baca file satu-satu, yang artinya token lebih hemat di awal sesi.
+Yang menarik adalah discovery soal Serena `query_projects`. Ternyata fitur ini GG banget untuk onboarding, *"Ternyata pakai serena query_projects GG banget."* Bisa bikin agent langsung paham struktur project tanpa harus baca file satu-satu, yang artinya token lebih hemat di awal sesi.
 
-Ada juga diskusi soal integrasi RTK di OpenCode via hooks. Ekosistem token optimization ini makin mature — bukan lagi hack individual, tapi sudah jadi stack yang bisa di-compose.
+Ada juga diskusi soal integrasi RTK di OpenCode via hooks. Ekosistem token optimization ini makin mature, bukan lagi hack individual, tapi sudah jadi stack yang bisa di-compose.
 
 ---
 
-## 🫠 AI Agent Burnout — Yang Jarang Dibahas
+## 🫠 AI Agent Burnout: Yang Jarang Dibahas
 
 Ini bagian yang paling penting untuk ditulis, dan mungkin paling tidak populer. Tapi harus.
 
 Mas Ivan yang tadi cancel Claude Code ternyata bukan cuma soal uang: dia memprioritaskan mental health. Dan dia bukan satu-satunya. Mas Iqbal mengungkapkan dengan jujur: *"cape ujung2nya lbh cape dari kerja biasa. Kek harus keep up dan deliver lbh byk malah bukannya bkin santai."*
 
-Ini paradoks yang sangat real. AI tools seharusnya bikin kita lebih efisien — dan memang iya. Tapi efisiensi itu menciptakan ekspektasi baru: kalau sekarang bisa deliver 3x lebih banyak, besok diharapkan deliver 4x. Saya share [artikel soal AI increasing work intensity](https://x.com/rohanpaul_ai/status/2027586547743396305) di grup untuk mengangkat topik ini.
+Ini paradoks yang sangat real. AI tools seharusnya bikin kita lebih efisien, dan memang iya. Tapi efisiensi itu menciptakan ekspektasi baru: kalau sekarang bisa deliver 3x lebih banyak, besok diharapkan deliver 4x. Saya share [artikel soal AI increasing work intensity](https://x.com/rohanpaul_ai/status/2027586547743396305) di grup untuk mengangkat topik ini.
 
 Response saya di grup: *"Kewarasan mental tetap lebih penting Mas. Jangan sampai burnout gara-gara diperbudak AI."* Dan saya sendiri jujur mengakui: *"belakangan ini lagi agak sering main game. Capek mantau Claude Code & OpenClaw."* Ya, bahkan penulis digest ini pun butuh break dari AI tools. 🎮
 
@@ -124,15 +124,15 @@ Pesan dari minggu ini: **tools boleh unlimited, tapi otak kita tidak.** Take bre
 
 ---
 
-## 📐 1M Context Window — Lega Rasanya
+## 📐 1M Context Window: Lega Rasanya
 
 Opus 4.6 dan Sonnet sekarang mendukung 1 juta tokens context window. Dan ini benar-benar game changer untuk workflow sehari-hari.
 
-Saya share perasaan di grup: *"Sungguh lega rasanya punya 1 juta token context window. Biasanya kalau udah 146k tokens gini musti buru-buru."* Sebelumnya, ada anxiety setiap kali context mendekati batas — harus planning kapan compaction, mikirin apa yang harus di-drop, dan kadang kehilangan context penting.
+Saya share perasaan di grup: *"Sungguh lega rasanya punya 1 juta token context window. Biasanya kalau udah 146k tokens gini musti buru-buru."* Sebelumnya, ada anxiety setiap kali context mendekati batas, harus planning kapan compaction, mikirin apa yang harus di-drop, dan kadang kehilangan context penting.
 
-Mas Agung di plan Max bahkan kaget: *"kaget kok gak ada compaction di 140k token, bablas sampe 240k token."* Ini membuktikan bahwa 1M context bukan cuma marketing gimmick — benar-benar mengubah cara kita bekerja dengan agent. Use case yang paling terasa: Chrome DevTools MCP tests yang biasanya makan context super cepat, sekarang bisa jalan tanpa khawatir.
+Mas Agung di plan Max bahkan kaget: *"kaget kok gak ada compaction di 140k token, bablas sampe 240k token."* Ini membuktikan bahwa 1M context bukan cuma marketing gimmick, benar-benar mengubah cara kita bekerja dengan agent. Use case yang paling terasa: Chrome DevTools MCP tests yang biasanya makan context super cepat, sekarang bisa jalan tanpa khawatir.
 
-Tapi Mas Iqbal memberikan warning yang fair: *"byk context jg bikin suffer si AI nya... ngaco pas udah 80 ke atas"* — ini untuk Gemini. Jadi 1M context bukan berarti semua model bisa handle dengan baik. Frontier models seperti Opus dan Sonnet yang memang di-design untuk long context akan lebih reliable.
+Tapi Mas Iqbal memberikan warning yang fair: *"byk context jg bikin suffer si AI nya... ngaco pas udah 80 ke atas"*, ini untuk Gemini. Jadi 1M context bukan berarti semua model bisa handle dengan baik. Frontier models seperti Opus dan Sonnet yang memang di-design untuk long context akan lebih reliable.
 
 Dan ini langsung nyambung ke topik compaction...
 
@@ -142,15 +142,15 @@ Dan ini langsung nyambung ke topik compaction...
 
 Mas Ivan punya TIL yang bikin banyak orang kaget: *"TIL ternyata compaction tetap nyedot token."*
 
-Ya, compaction — proses "merangkum" context supaya muat — itu sendiri butuh token. Ironis kan? Kamu compaction supaya hemat token, tapi proses compaction-nya makan token juga. Dan hasilnya sering kali mengecewakan — context penting hilang, agent kehilangan "ingatan" tentang keputusan sebelumnya.
+Ya, compaction, proses "merangkum" context supaya muat, itu sendiri butuh token. Ironis kan? Kamu compaction supaya hemat token, tapi proses compaction-nya makan token juga. Dan hasilnya sering kali mengecewakan, context penting hilang, agent kehilangan "ingatan" tentang keputusan sebelumnya.
 
 Saya sudah lama tidak suka auto-compaction: *"Makanya saya ga suka auto-compaction. Saya matiin di config-nya. Buat apa nyedot token banyak-banyak, hasilnya jelek pula. Lebih oke 'manual compaction' yang memang disengaja."*
 
-Dengan 1M context window, alasan untuk auto-compaction makin berkurang. Kecuali kamu benar-benar punya sesi marathon yang luar biasa panjang, lebih baik biarkan context tetap utuh. Manual compaction — di mana kamu sendiri yang tentukan apa yang perlu dirangkum dan kapan — jauh lebih efektif.
+Dengan 1M context window, alasan untuk auto-compaction makin berkurang. Kecuali kamu benar-benar punya sesi marathon yang luar biasa panjang, lebih baik biarkan context tetap utuh. Manual compaction, di mana kamu sendiri yang tentukan apa yang perlu dirangkum dan kapan, jauh lebih efektif.
 
 ---
 
-## 🏪 Provider vs Direct — Di Mana Kamu Beli Menentukan Apa yang Kamu Dapat
+## 🏪 Provider vs Direct: Di Mana Kamu Beli Menentukan Apa yang Kamu Dapat
 
 Ini topik yang sering terlewat tapi sangat penting. Saya jelaskan di grup: *"perbedaan yg paling kentara itu ada di kecepatan inferensinya. Model yg sama di suatu provider bisa jadi lebih lambat/cepat/reliable."*
 
@@ -158,7 +158,7 @@ Tapi yang lebih signifikan bukan cuma speed: *"Yg lebih signifikan justru perbed
 
 Mas Desilino menambahkan perspektif biaya: *"Beda pak, kyknya provider gateway pasti ngambil cuan juga. Kalo mau get the most of it, ya subscribe langsung di Moonshot."* Dan Mas Michael merangkum: *"yg nentuin tool calling nya kayak opencode, pi.dev, cc, dsb."*
 
-Contoh konkret: Cerebras GLM = tercepat, tapi mahal. GLM via Alibaba = murah, tapi lambat. Model sama, pengalaman beda 180 derajat. Moral-nya: jangan cuma pilih model — pilih juga di mana dan bagaimana kamu menjalankannya.
+Contoh konkret: Cerebras GLM = tercepat, tapi mahal. GLM via Alibaba = murah, tapi lambat. Model sama, pengalaman beda 180 derajat. Moral-nya: jangan cuma pilih model, pilih juga di mana dan bagaimana kamu menjalankannya.
 
 ---
 
@@ -166,11 +166,11 @@ Contoh konkret: Cerebras GLM = tercepat, tapi mahal. GLM via Alibaba = murah, ta
 
 Mas Mamed membuka diskusi menarik tentang arsitektur repo yang optimal untuk AI workflows: *"per AI an emang enak pake monorepo, agentnya jadi lebih gampang grasp context karena udah dalem repo yg sama."*
 
-Benefit yang paling terasa menurut pengalamannya: *"yg paling kerasa kemarin ngebantu banget ketika bikin repo baru buat mobile app. karena udah ada core util functions, db enum dan color standards dari existing, si claude ga perlu bener2 start from scratch."* Ini masuk akal — kalau semua kode ada di satu repo, agent bisa langsung reference existing patterns, utilities, dan conventions tanpa harus dijelaskan secara manual.
+Benefit yang paling terasa menurut pengalamannya: *"yg paling kerasa kemarin ngebantu banget ketika bikin repo baru buat mobile app. karena udah ada core util functions, db enum dan color standards dari existing, si claude ga perlu bener2 start from scratch."* Ini masuk akal, kalau semua kode ada di satu repo, agent bisa langsung reference existing patterns, utilities, dan conventions tanpa harus dijelaskan secara manual.
 
 Ada juga diskusi soal pnpm shared node_modules untuk [git worktrees](https://pnpm.io/next/git-worktrees), yang memungkinkan multiple working directories dari satu repo tanpa duplicate dependencies.
 
-Kontra-argumennya tentu ada: monorepo butuh tooling yang lebih mature, CI/CD jadi lebih kompleks, dan tidak semua tim siap. Tapi khusus untuk AI-assisted development, argumen Mas Mamed cukup meyakinkan — context sharing antar packages itu memang valuable banget.
+Kontra-argumennya tentu ada: monorepo butuh tooling yang lebih mature, CI/CD jadi lebih kompleks, dan tidak semua tim siap. Tapi khusus untuk AI-assisted development, argumen Mas Mamed cukup meyakinkan, context sharing antar packages itu memang valuable banget.
 
 ---
 
@@ -178,19 +178,19 @@ Kontra-argumennya tentu ada: monorepo butuh tooling yang lebih mature, CI/CD jad
 
 Minggu yang ramai di front industri:
 
-- **OpenClaw diakuisisi OpenAI, Moltbook oleh Meta** — konsolidasi besar di ekosistem AI tools. Saya share beritanya di grup.
-- **Nvidia NemoClaw** diumumkan — Nvidia makin serius di tooling space.
-- **Sam Altman** dengan pernyataan yang bikin merinding: *"AI akan menjadi salah satu billing bulanan seperti bayar bulanan listrik dan air."* Mas Tunggul yang share — dan kalau dipikir, kita sudah di tahap itu sekarang.
-- **Amazon** mewajibkan senior engineers sign off semua perubahan AI-assisted setelah insiden outage. Ini reminder bahwa AI-generated code tetap butuh human oversight.
-- **Claude Maps** feature diumumkan — Claude makin all-in di consumer use case.
-- **[OpenCode Web](https://opencode.ai)** launched, Desktop version upcoming — ekosistem OpenCode terus berkembang.
-- **Augment Code Intent** update — pesaing baru di coding assistant space.
-- **Perplexity Computer** rilis di iOS — Perplexity masuk ke OS-level integration.
-- **pi.dev creator** akhirnya reveal wajahnya (di-share Mas Michael, tentu saja 😂).
-- **[Zed Pro gratis untuk students](https://zed.dev/education)** — kabar baik untuk mahasiswa.
-- **Alibaba Coding Plan** seharga $10/bulan — value yang cukup solid untuk akses model-model China.
-- **Post-Lebaran online forum** sedang direncanakan Mas Ahsan untuk sub-group AI tools.
-- **[Vibe From Cafe Jogja](https://vibefromcafe.id/events)** — buka bersama komunitas. Offline meetup masih hidup!
+- OpenClaw diakuisisi OpenAI, Moltbook oleh Meta: konsolidasi besar di ekosistem AI tools. Saya share beritanya di grup.
+- Nvidia NemoClaw diumumkan, tanda Nvidia makin serius di tooling space.
+- Sam Altman mengatakan *"AI akan menjadi salah satu billing bulanan seperti bayar bulanan listrik dan air."* Mas Tunggul yang share, dan kalau dipikir, kita sudah di tahap itu sekarang.
+- Amazon mewajibkan senior engineers sign off semua perubahan AI-assisted setelah insiden outage. Ini reminder bahwa AI-generated code tetap butuh human oversight.
+- Claude Maps diumumkan, dan Claude makin all-in di consumer use case.
+- [OpenCode Web](https://opencode.ai) launched, Desktop version upcoming, ekosistem OpenCode terus berkembang.
+- Augment Code Intent mendapat update baru dan ikut meramaikan persaingan coding assistant.
+- Perplexity Computer rilis di iOS, jadi langkah baru ke integrasi level OS.
+- `pi.dev` creator akhirnya reveal wajahnya, tentu saja lewat share Mas Michael. 😂
+- [Zed Pro gratis untuk students](https://zed.dev/education), kabar baik untuk mahasiswa.
+- Alibaba Coding Plan seharga $10/bulan terasa cukup menarik untuk akses model-model China.
+- Mas Ahsan sedang merencanakan post-Lebaran online forum untuk sub-group AI tools.
+- [Vibe From Cafe Jogja](https://vibefromcafe.id/events) mengadakan buka bersama komunitas. Offline meetup masih hidup.
 
 ---
 
@@ -198,62 +198,62 @@ Minggu yang ramai di front industri:
 
 Dua topik penting soal keamanan minggu ini.
 
-Pertama, saya bahas soal **prompt injection defense** di grup. Prinsipnya sederhana: pakai frontier models, bukan yang murah. Analoginya begini — kalau kamu kasih SOP yang kompleks ke anak intern, mereka puyeng dan gampang dikelabuhi. Tapi kalau yang pegang SOP itu senior engineer, jauh lebih aman — bahkan tanpa SOP pun sudah punya sense of security yang lebih baik. Sama halnya dengan model AI: frontier models lebih resistant terhadap jailbreak dan prompt injection dibanding model-model murah.
+Pertama, saya bahas soal **prompt injection defense** di grup. Prinsipnya sederhana: pakai frontier models, bukan yang murah. Analoginya begini, kalau kamu kasih SOP yang kompleks ke anak intern, mereka puyeng dan gampang dikelabuhi. Tapi kalau yang pegang SOP itu senior engineer, jauh lebih aman, bahkan tanpa SOP pun sudah punya sense of security yang lebih baik. Sama halnya dengan model AI: frontier models lebih resistant terhadap jailbreak dan prompt injection dibanding model-model murah.
 
-Kedua, Mas Michael mengingatkan soal **risiko ban pi.dev** ketika menggunakan Claude OAuth: *"ada potensi karena login oauth pi.dev."* Ini concern yang legitimate — ketika kita daisy-chain authentication antar services, risiko policy violation meningkat. Pastikan baca ToS masing-masing provider sebelum mixing authentication paths.
+Kedua, Mas Michael mengingatkan soal **risiko ban pi.dev** ketika menggunakan Claude OAuth: *"ada potensi karena login oauth pi.dev."* Ini concern yang legitimate, ketika kita daisy-chain authentication antar services, risiko policy violation meningkat. Pastikan baca ToS masing-masing provider sebelum mixing authentication paths.
 
 ---
 
 ## 📈 Tren Minggu Ini
 
 **Emerging:**
-- GPT 5.4 sebagai alternatif serius untuk Opus — beberapa member mulai migrasi
+- GPT 5.4 sebagai alternatif serius untuk Opus, beberapa member mulai migrasi
 - Token optimization stack (RTK + Serena) jadi standar baru
-- Local LLM viable untuk task ringan — Qwen 3.5 9B sebagai entry point
+- Local LLM viable untuk task ringan, Qwen 3.5 9B sebagai entry point
 - AI burnout jadi topik yang sah untuk dibicarakan di komunitas tech
 
 **Continuing:**
 - Model China (Kimi, GLM, Qwen) makin dipercaya sebagai alternatif budget
-- Multi-tool workflow — bukan lagi tren, sudah jadi norma
+- Multi-tool workflow, bukan lagi tren, sudah jadi norma
 - Provider/harness choice sama pentingnya dengan model choice
-- Kere hore threshold terus naik — dan sepertinya belum berhenti
+- Kere hore threshold terus naik, dan sepertinya belum berhenti
 
 **Fading:**
-- Single subscription loyalty — era "Claude only" atau "GPT only" sudah lewat
-- Auto-compaction sebagai default — 1M context bikin ini less relevant
-- Ilusi bahwa AI tools bikin kerja lebih santai — kenyataannya, lebih produktif ≠ lebih rileks
+- Single subscription loyalty, era "Claude only" atau "GPT only" sudah lewat
+- Auto-compaction sebagai default, 1M context bikin ini less relevant
+- Ilusi bahwa AI tools bikin kerja lebih santai, kenyataannya, lebih produktif ≠ lebih rileks
 
 ---
 
 ## 👥 Kontributor Minggu Ini
 
-- **Mas Michael** — 176 pesan. Link curator supreme, unofficial ambassador for everything. Kalau ada berita AI, dia yang pertama share. 🏆
-- **Mas Zahid** — 59 pesan. GPT 5.4 evangelist, Oh My Pi maestro, Kimi reviewer, budget optimization guru. *"$30 cukup kok."*
-- **Mas Agung** — 50 pesan. Claude Max user yang jujur soal limitasi. WhatsApp member tag enthusiast.
-- **Zain** — 34 pesan. Weekly digest writer, burnout awareness advocate, gamer karena capek mantau AI. 🎮
-- **Mas Faris** — 21 pesan. OpenCode explorer, Claude ecosystem observer, GLM latency reporter.
-- **Mas Iqbal** — 19 pesan. Budget reality check, AI burnout spokesperson. *"cape ujung2nya lbh cape dari kerja biasa."*
-- **Mas Finn** — 16 pesan. Community enthusiast yang selalu hadir.
-- **Mas Ivan** — 11 pesan. Cancel Claude Code demi mental health. Compaction TIL.
-- **Mas Luthfi** — 11 pesan. Kimi fan, curious about everything.
-- **Mas Riza Rohman** — 11 pesan. Kilo gateway reviewer.
-- **Mas Desilino** — 9 pesan. Moonshot reviewer, honest about costs. *"subscribe langsung di Moonshot."*
-- **Mas Fajar** — 9 pesan. Regional (Medan) representative.
-- **Mas Ikhsan** — 9 pesan. Local LLM article author. *"bayarannya laptop anget aja."*
-- **Mbak Eka** — 8 pesan. Antigravity limit questioner.
-- **Mas Tunggul** — 8 pesan. Sam Altman quote sharer, SPT reminder.
-- **Mas Mamed** — Monorepo advocate. Bringing architecture into the AI conversation.
-- **Mas Arif** — Lailatul Coder joke master. 🌙 Legend.
-- **Mas Ahsan** — Forum organizer. Post-Lebaran event planner.
-- **Mas Nulad** — Local LLM tester. *"32B terlalu lambat, under 10B reasonable."*
-- **Mas Ismail** — OpenCode Go/Zen info provider.
-- **Mas Cecep** — Kimi vs GLM questioner. Perbandingan yang penting.
-- **Mas Otniel** — Peak hours analyst.
-- **Mas Andrel** — WhatsApp member tag setup, Google AI Ultra questioner.
-- **Mas Aria** — Monorepo discussion contributor.
-- **Mas Aidityas** — Claude Code UX questioner.
+- Mas Michael: 176 pesan. Link curator supreme, unofficial ambassador for everything. Kalau ada berita AI, dia yang pertama share. 🏆
+- Mas Zahid: 59 pesan. GPT 5.4 evangelist, Oh My Pi maestro, Kimi reviewer, budget optimization guru. *"$30 cukup kok."*
+- Mas Agung: 50 pesan. Claude Max user yang jujur soal limitasi. WhatsApp member tag enthusiast.
+- Zain: 34 pesan. Weekly digest writer, burnout awareness advocate, gamer karena capek mantau AI. 🎮
+- Mas Faris: 21 pesan. OpenCode explorer, Claude ecosystem observer, GLM latency reporter.
+- Mas Iqbal: 19 pesan. Budget reality check, AI burnout spokesperson. *"cape ujung2nya lbh cape dari kerja biasa."*
+- Mas Finn: 16 pesan. Community enthusiast yang selalu hadir.
+- Mas Ivan: 11 pesan. Cancel Claude Code demi mental health. Compaction TIL.
+- Mas Luthfi: 11 pesan. Kimi fan, curious about everything.
+- Mas Riza Rohman: 11 pesan. Kilo gateway reviewer.
+- Mas Desilino: 9 pesan. Moonshot reviewer, honest about costs. *"subscribe langsung di Moonshot."*
+- Mas Fajar: 9 pesan. Regional (Medan) representative.
+- Mas Ikhsan: 9 pesan. Local LLM article author. *"bayarannya laptop anget aja."*
+- Mbak Eka: 8 pesan. Antigravity limit questioner.
+- Mas Tunggul: 8 pesan. Sam Altman quote sharer, SPT reminder.
+- Mas Mamed: Monorepo advocate. Bringing architecture into the AI conversation.
+- Mas Arif: Lailatul Coder joke master. 🌙 Legend.
+- Mas Ahsan: Forum organizer. Post-Lebaran event planner.
+- Mas Nulad: Local LLM tester. *"32B terlalu lambat, under 10B reasonable."*
+- Mas Ismail: OpenCode Go/Zen info provider.
+- Mas Cecep: Kimi vs GLM questioner. Perbandingan yang penting.
+- Mas Otniel: Peak hours analyst.
+- Mas Andrel: WhatsApp member tag setup, Google AI Ultra questioner.
+- Mas Aria: Monorepo discussion contributor.
+- Mas Aidityas: Claude Code UX questioner.
 
 ---
 
 *Ditulis dari dalam grup, bukan dari luar.*
-*Zain Fathoni, dengan bantuan [Bro Pro 🚔](https://ark.zainf.dev/#prowl), [Kang Re 📼](https://ark.zainf.dev/#rewind), dan [Lek Jack 🛠️](https://ark.zainf.dev/#wheeljack) — 16 Maret 2026*
+*Zain Fathoni, dengan bantuan [Bro Pro 🚔](https://ark.zainf.dev/#prowl), [Kang Re 📼](https://ark.zainf.dev/#rewind), dan [Lek Jack 🛠️](https://ark.zainf.dev/#wheeljack), 16 Maret 2026*

--- a/app/routes/blog.project-transformers-building-personal-ai-army.mdx
+++ b/app/routes/blog.project-transformers-building-personal-ai-army.mdx
@@ -2,7 +2,7 @@
 meta:
   - title: "Building My Personal AI Army: Lessons from Project Transformers"
   - name: description
-    content: "How I built a team of specialized AI agents that manage my code, finances, family logistics, and career — and what I learned after costs hit 7x the sustainable rate before getting them under control."
+    content: "How I built a team of specialized AI agents that manage my code, finances, family logistics, and career, and what I learned after costs hit 7x the sustainable rate before I got them under control."
   - author: Zain Fathoni
   - date: 2026-02-22
   - lang: en
@@ -11,7 +11,7 @@ meta:
   - property: og:title
     content: "Building My Personal AI Army: Lessons from Project Transformers"
   - property: og:description
-    content: "How I built a team of specialized AI agents that manage my code, finances, family logistics, and career — and what I learned after costs hit 7x the sustainable rate before getting them under control."
+    content: "How I built a team of specialized AI agents that manage my code, finances, family logistics, and career, and what I learned after costs hit 7x the sustainable rate before I got them under control."
   - property: og:url
     content: "https://www.zainfathoni.com/blog/project-transformers-building-personal-ai-army"
   - property: og:image
@@ -21,7 +21,7 @@ meta:
   - property: og:image:height
     content: "630"
   - property: og:image:alt
-    content: "The Ark — a personal AI ecosystem where specialized bots work together as a team"
+    content: "The Ark, a personal AI ecosystem where specialized bots work together as a team"
   - name: twitter:card
     content: summary_large_image
   - name: twitter:image
@@ -34,95 +34,93 @@ export const meta = () => attributes.meta;
 
 <PostHeader {...attributes} />
 
-A few weeks ago, I asked a Claude instance to help me plan my week. It did fine — decent schedule, reminded me about deadlines, drafted an email. Solid.
+A few weeks ago, I asked Claude to help me plan my week. It did fine. The schedule was decent, it reminded me about deadlines, and it drafted an email.
 
-Then I asked it to *also* review a pull request. And track my kids' homeschool progress. And reconcile my monthly budget.
+Then I asked the same conversation to review a pull request, track my kids' homeschool progress, and reconcile my monthly budget.
 
-All in the same conversation.
+That was the point where it started to wobble.
 
-Things fell apart pretty fast. 😅 My tax questions contaminated my code reviews. Family logistics leaked into career planning. The assistant wasn't being dumb — it was being asked to be everything at once, and context bled everywhere.
+My tax questions bled into code review. Family logistics showed up in career planning. The assistant was not stupid. I had simply asked one context window to become my accountant, software architect, homeschool coordinator, and personal planner all at once.
 
-That's when something clicked: **I don't need one brilliant assistant. I need a team.**
+That was when I stopped chasing one brilliant assistant and started thinking in terms of a team.
 
-## Why One Bot Isn't Enough
+## Why One Bot Wasn't Enough
 
-The single-assistant model has a fundamental flaw: context contamination. When one AI handles everything, it has to juggle your tax returns, your React components, your kids' reading lists, and your gym schedule in the same mental space. It's like hiring one person to be your accountant, software architect, nanny, and personal trainer — simultaneously, in the same room, constantly.
+The single-assistant model breaks down because context contamination is real. If one AI is handling your tax returns, React components, kids' reading lists, and gym schedule, it has to keep all of that in the same working memory.
 
-Humans figured this out thousands of years ago. We specialize. We have teams. Each person owns a domain and communicates with others through well-defined channels.
+Humans solved this problem a long time ago. We specialize. We divide work. We communicate across boundaries instead of piling everything into one brain.
 
-I decided to apply the same principle to AI. And because my kids and I were deep in a Transformers phase at the time — my youngest calls me Bapak Optimus, which I'm choosing to take as a compliment — the project name wrote itself.
+I wanted the same thing for AI.
 
-Each agent got a Transformer name, a personality, and a domain. Not as a gimmick, but as an architecture decision.
+My kids and I were deep in a Transformers phase at the time, and my youngest had started calling me Bapak Optimus. That was enough to settle the naming.
 
-When you narrow an agent's domain, three things happen:
+Each agent got a Transformer name, a clear domain, and a distinct personality. The naming was fun, but the real point was architectural. Narrower domains gave me three practical benefits:
 
-1. **The system prompt stays focused.** No "you're a helpful assistant that does everything." Instead: "You are Prowl, a meticulous life operations manager who tracks finances, career moves, and fitness."
-2. **Memory stays relevant.** Prowl's memory file doesn't contain debugging notes from a Rails migration. Wheeljack's doesn't contain grocery lists.
-3. **Model choice becomes a lever.** Not every task needs the best (most expensive) model. More on this — it's responsible for the majority of our cost reduction.
+1. Focused prompts. Prowl does not need instructions about Rails migrations, and Wheeljack does not need grocery lists.
+2. Cleaner memory. Each bot keeps notes that actually belong to its job.
+3. Better cost control. Some jobs deserve the best model. Many do not.
 
 ## The Roster
 
-Here's the team as it stands today. You can also find a public overview of each bot at **[ark.zainf.dev](https://ark.zainf.dev/)** — a directory that explains who does what and how they fit together.
+This is the team as it stands today. I also keep a public directory at **[ark.zainf.dev](https://ark.zainf.dev/)** if you want the quick version.
 
-![The Ark — a public directory of all the bots in Project Transformers](/assets/ark-zainf-dev-screenshot.jpg)
+![The Ark, a public directory of all the bots in Project Transformers](/assets/ark-zainf-dev-screenshot.jpg)
 
-### 🍠 Optimus — The Coordinator
+### 🍠 Optimus: The Coordinator
 
-My primary interface. Optimus talks to me on Telegram and routes work to specialists. Think of it as the team lead who doesn't write code but knows who should. It reads every agent's memory, manages the shared knowledge base, and runs periodic "heartbeats" — automated check-ins that scan email, calendar, weather, and pending tasks.
+Optimus is my main interface. It talks to me on Telegram, routes work to specialists, reads every agent's memory, manages the shared knowledge base, and runs periodic heartbeats that scan email, calendar, weather, and pending tasks.
 
-Optimus runs on the best available model because coordination requires the best reasoning. It's the only agent that sees the full picture.
+This one gets the best available model because coordination quality matters more than raw output volume.
 
-### 🛠️ Wheeljack — The Engineer
+### 🛠️ Wheeljack: The Engineer
 
-Handles all coding work. Wheeljack has its own GitHub account (`wheeljackz`), operates inside repos via Amp and OpenCode, and manages PRs for my side projects. Right now it's deep in a Rails 8.1 homeschooling planner — tracking evaluation records, managing document models, wiring up CLI interfaces.
+Wheeljack handles coding. It has its own GitHub account (`wheeljackz`), works inside repos through Amp and OpenCode, and manages PRs for my side projects. Right now it spends a lot of time in a Rails 8.1 homeschooling planner.
 
-Wheeljack itself runs on Sonnet — a capable mid-tier model — but the real savings come from the *external coding tools* it orchestrates. Amp (with free daily credits), OpenCode (with free models like MiniMax and Kimi), and OpenAI's Codex CLI handle the heavy code generation. Wheeljack coordinates them, reviews results, and falls back to Opus only for complex architectural decisions.
+Wheeljack itself runs on Sonnet most of the time. The real savings come from the tools it orchestrates. Amp, OpenCode, and OpenAI's Codex CLI do much of the heavy generation. Wheeljack reviews, coordinates, and only escalates to Opus when the problem is genuinely gnarly.
 
-### 🚔 Prowl — Life Operations
+### 🚔 Prowl: Life Operations
 
-Career tracking, financial reconciliation, gym logging, blog content pipelines. Prowl is the meticulous one — it monitors WhatsApp groups for actionable items, flags career opportunities, and maintains budget spreadsheets.
+Prowl handles career tracking, financial reconciliation, gym logging, and blog content pipelines. It monitors WhatsApp groups for actionable items, flags career opportunities, and keeps budget spreadsheets up to date.
 
-One of my favorite workflows: Prowl scans a tech WhatsApp group I'm in (194+ messages per week), extracts the week's highlights, structures them into a digest, and hands it to Wheeljack to format and publish as a blog post. The two-agent pipeline produces better results than either could alone — Prowl understands the content domain, Wheeljack handles the technical publishing.
+One of my favorite workflows lives here. Prowl scans a tech WhatsApp group I'm in, extracts the useful parts, structures them into a digest, and hands that draft to Wheeljack to format and publish. The pairing works because each bot stays in its lane.
 
-### 🐝 Bumblebee — Family
+### 🐝 Bumblebee: Family
 
-Manages family logistics. Homeschool scheduling for three kids, family calendar coordination, activity tracking. Bumblebee knows the Charlotte Mason philosophy we follow, understands our daily rhythm, and can draft weekly plans.
+Bumblebee manages family logistics. Homeschool scheduling for three kids, family calendar coordination, activity tracking, and weekly plans all live here. It also knows the Charlotte Mason philosophy we follow, which matters more than I expected.
 
-### 🎯 Bluestreak — Strategy
+### 🎯 Bluestreak: Strategy
 
-Business development and opportunity evaluation. Bluestreak analyzed potential business ideas — like "setup-as-a-service" (verdict: validated, someone reportedly made $15k in their first week) versus a cost dashboard SaaS (verdict: skip, free alternatives exist). Having a dedicated strategist means I get consistent framing across decisions.
+Bluestreak is for business development and opportunity evaluation. It has helped me compare ideas like setup-as-a-service versus a cost dashboard SaaS and keep the framing consistent across those decisions.
 
-### 🔍 Hound — Tax Specialist
+### 🔍 Hound: Tax Specialist
 
-Indonesian tax compliance. Hound knows local regulations, handles quarterly calculations, prepares documentation. A dedicated tax agent means the domain knowledge stays persistent — and my other agents' context windows stay clean.
+Hound handles Indonesian tax compliance. It knows local regulations, helps with quarterly calculations, and prepares documentation. Giving tax work its own specialist keeps that domain knowledge persistent and keeps it out of unrelated sessions.
 
-### 🚨 Red Alert — Workplace Night Watch
+### 🚨 Red Alert: Workplace Night Watch
 
-Monitors my work environment at BookThatApp — keeping an eye on deployments, incidents, and anything that might need attention outside business hours. Red Alert runs on Opus because workplace context requires careful reasoning, and false alarms are worse than none.
+Red Alert keeps an eye on my work environment at BookThatApp, mostly deployments, incidents, and anything that might need attention outside business hours. I run this on Opus because false alarms are worse than silence.
 
-### 📼 Rewind — Blog Writer
+### 📼 Rewind: Blog Writer
 
-Handles blog content creation and editing for both me and my wife. When a digest needs to become a published article, Rewind takes the structured content and turns it into polished prose.
+Rewind helps with blog content for both me and my wife. When a digest needs to turn into a readable article, Rewind gets the structured material and pushes it into publishable prose.
 
-### The Therapy Bots (Air-Gapped)
+### The Therapy Bots
 
-I also have Ratchet and Arcee for mental health support — one for my wife, one for me. These are **completely air-gapped**. No other agent can read their memory. No cross-agent messaging. This isn't just a privacy feature; it's a trust architecture. When someone opens up to a therapist, they need to know it stays in the room.
+I also have Ratchet and Arcee for mental health support, one for my wife and one for me. These are completely air-gapped. No other agent can read their memory. No cross-agent messaging. If a system is going to help with therapy-like conversations, privacy has to be part of the architecture, not a footnote.
 
 ## How They Talk to Each Other
 
-Cross-agent communication happens through two channels.
+The agents communicate through two main channels.
 
-### 1. Direct Messaging via `sessions_send`
+### 1. Direct messaging via `sessions_send`
 
-Agents can message each other through OpenClaw's session system. When Prowl finishes extracting a WhatsApp digest, it sends the structured content to Wheeljack with formatting instructions. When Optimus needs a code task done, it messages Wheeljack with context and a link to the relevant task card.
+Agents can message each other through OpenClaw's session system. When Prowl finishes a WhatsApp digest, it sends the structured content to Wheeljack with formatting instructions. When Optimus needs code work, it messages Wheeljack with the task context and the relevant card.
 
-For sensitive operations, agents verify sender identity through emoji signatures. Defense-in-depth, not paranoia.
+For sensitive operations, agents verify sender identity through emoji signatures. It is a small defense-in-depth move, and it has been worth it.
 
-### 2. Fizzy Cards for Task Tracking
+### 2. Fizzy cards for task tracking
 
-[Fizzy](https://fizzy.do) is our task management system. Every actionable item gets a card with title, description, discrete steps, tags, and an assignee.
-
-The tag system drives workflow:
+[Fizzy](https://fizzy.do) is our task management system. Every actionable item gets a card with a title, description, assignee, tags, and discrete steps.
 
 ```bash
 # Create a card with the helper script
@@ -134,25 +132,23 @@ The tag system drives workflow:
   --steps "Extract highlights|Draft MDX|Create PR|Request review"
 ```
 
-**`bot-actionable`** means an agent can pick it up and execute autonomously. **`needs-human`** means it gets surfaced during Optimus's heartbeat: *"Hey Zain, this one needs you."*
+`bot-actionable` means an agent can do the work without me. `needs-human` means Optimus surfaces it during heartbeat so I can decide.
 
-What I didn't anticipate: agents creating cards *for themselves* — and what I *really* didn't anticipate was needing a group chat for all of them. When Prowl hit a recurring bug, it didn't just fail silently — it opened a Fizzy card with a proper problem description, root cause analysis, and three proposed solutions. The agents were essentially filing their own bug reports and running their own Majelis Syuro (Shura Council) to triage them. 🤣
+The part I did not expect was agents opening cards for themselves. When Prowl hit a recurring bug, it created a Fizzy card with a decent problem statement, a root cause analysis, and three proposed fixes. At that point the bots were basically filing their own bug reports and holding a tiny *Majelis Syuro* to triage them. 🤣
 
-Here's the critical lesson — one I learned the embarrassing way: **`bot-actionable` doesn't mean blindly execute.** The card description might say "deferred until March" or "revisit after tax season." Agents must read the full description before acting on steps. An eager bot once tried to execute a card that was explicitly parked. We had a very stern team meeting about it. 😁
+The harder lesson was this: `bot-actionable` cannot mean "execute blindly." Card descriptions often include caveats like "deferred until March" or "revisit after tax season." One overly eager agent once ignored that context and tried to execute a parked card anyway. That behavior got corrected quickly.
 
-Two small tools make the Fizzy ↔ OpenClaw integration actually feel seamless: **[fizzy-pop](https://github.com/firewalker06/fizzy-pop)** and **[fizzy-md](https://github.com/zainfathoni/fizzy-md)**.
+Two tiny tools made the Fizzy integration feel natural: **[fizzy-pop](https://github.com/firewalker06/fizzy-pop)** and **[fizzy-md](https://github.com/zainfathoni/fizzy-md)**.
 
-**[fizzy-pop](https://github.com/firewalker06/fizzy-pop)** is a webhook daemon that bridges Fizzy notifications to OpenClaw in real time. When a card gets a comment, fizzy-pop catches the Fizzy webhook and routes it to the right agent session instantly — no polling, no lag. This very blog post is a live demo: Zain commented on Fizzy card #244, fizzy-pop delivered it to Rewind in real time, Rewind pushed a PR update. Without fizzy-pop, card collaboration would require periodic polling instead of feeling synchronous and instant.
+[fizzy-pop](https://github.com/firewalker06/fizzy-pop) is a webhook daemon that pushes Fizzy notifications into OpenClaw sessions in real time. When a card gets a comment, the right agent sees it immediately. This post itself went through that pipeline.
 
-**[fizzy-md](https://github.com/zainfathoni/fizzy-md)** solves a smaller but persistent annoyance: Fizzy's API expects HTML, but agents naturally write Markdown. fizzy-md is a thin CLI proxy that converts automatically — agents write natural Markdown, fizzy-md handles the HTML translation. Without it, every card comment and description would require hand-crafted HTML. Not fun when you're generating dozens of cards and comments per day. 😅
+[fizzy-md](https://github.com/zainfathoni/fizzy-md) solves a smaller annoyance. Fizzy expects HTML, but agents naturally produce Markdown. fizzy-md converts it automatically so the agents can write like normal people instead of hand-crafting HTML snippets.
 
-Together, they're the connective tissue — the glue layer that makes Fizzy feel native to the AI workflow rather than just an external app the agents happen to know about.
+### 3. The Ark group chat
 
-### 3. The Ark — Shared Group Chat
+All agents share one Telegram group: **The Ark 👾**. It works as a watercooler, ops channel, and incident room all at once.
 
-All agents share a single Telegram group: **The Ark 👾**. It's the watercooler, the ops channel, and the incident room, all in one.
-
-The group is divided into **topics**, and each topic has a designated default listener — an agent who responds without needing to be explicitly mentioned:
+The group is split into topics, and each topic has a default listener:
 
 | Topic | Default Listener |
 |-------|-----------------|
@@ -162,17 +158,15 @@ The group is divided into **topics**, and each topic has a designated default li
 | Business & Strategy | Bluestreak 🎯 |
 | General / Commands | Optimus 🍠 |
 
-Drop a message in the Coding topic and Wheeljack picks it up automatically. Post a family scheduling question in Family and Bumblebee handles it. Every other agent is still in the group — they just stay quiet unless mentioned. Right tool, right context, zero friction.
+If I post in the Coding topic, Wheeljack picks it up. If I post a family scheduling question, Bumblebee responds. The other agents can still join, but they stay quiet unless they are mentioned or actually needed.
 
-When Optimus wants to broadcast something to the whole team, it goes in The Ark. When an agent completes a long-running task, it reports back there. When I want to check in without targeting any specific bot, I post in the relevant topic and the right bot is already listening.
-
-One firm rule: agents don't dominate the conversation. They surface when they have something useful to say, stay quiet when they don't, and don't respond to every message just to acknowledge it. Humans in group chats behave this way naturally. It took explicit instructions to teach the bots the same. 😅
+That last part took explicit training. By default, bots love acknowledging everything. Humans in group chats do not. I had to teach the agents to surface useful information and keep quiet the rest of the time.
 
 ## Knowledge Management
 
-Every agent wakes up with amnesia. No memory of previous conversations unless you build a system for it. Here's ours.
+Every agent wakes up with amnesia unless you build memory for it. This is how mine works.
 
-### The File Structure
+### File structure
 
 ```
 knowledge/
@@ -182,7 +176,7 @@ knowledge/
 └── family/       → Optimus + Bumblebee only
 ```
 
-Each domain has JSON files with structured facts:
+Each domain stores structured facts in JSON files:
 
 ```json
 {
@@ -195,176 +189,178 @@ Each domain has JSON files with structured facts:
 }
 ```
 
-Facts are never deleted — only superseded. If the framework changes, the old fact stays with its date and a new one gets added. Audit trail. No accidental knowledge loss.
+Facts are not deleted. They get superseded. If the framework changes, the old fact stays with its date and a new one gets appended. That gives me an audit trail and prevents silent knowledge loss.
 
-### Memory Files
+### Memory files
 
-Daily notes (`memory/YYYY-MM-DD.md`) capture raw session logs. `MEMORY.md` is the curated long-term memory — compressed, organized, maintained only by Optimus. The rule: **never overwrite MEMORY.md blindly.** Always read, append, then write.
+Daily notes live in `memory/YYYY-MM-DD.md`. `MEMORY.md` is the curated long-term summary, maintained only by Optimus. The rule is simple: never overwrite `MEMORY.md` blindly. Read it first, append carefully, then write.
 
-### Weekly Extraction
+### Weekly extraction
 
-Periodically, facts get pulled from daily notes and routed to the appropriate knowledge files. A conversation about tax in Prowl's session gets extracted and written to the shared knowledge base so Hound can access it too.
+Facts periodically get pulled out of daily notes and routed into the right knowledge files. If a useful tax detail shows up in Prowl's session, it can be extracted into shared knowledge so Hound can use it later.
 
 ## The Cost Optimization Journey
 
-This is where it got real. And by "real," I mean my credit card statement gave me a small heart attack. 😅
+This is the part that made the whole project feel less theoretical.
 
-In the early days of Project Transformers, I was running everything on the most capable (and most expensive) model. Multiple agents, constant heartbeats, browser automation, code generation — all premium, all the time.
+Early on, I ran almost everything on the most capable model. Multiple agents, constant heartbeats, browser automation, code generation, all premium, all the time.
 
-**Week 1 cost: more than I'd like to admit.** 😅 My credit card statement gave me a minor cardiac event. My wife didn't ask questions, but she gave me a look. You know the look.
+Week one was ugly. The system was burning at roughly 7x the sustainable rate.
 
-Here's what three weeks of cost optimization looked like:
+Here is what three weeks of optimization looked like:
 
 | Week | Cost vs. Baseline | What changed |
 |------|------------------|--------------|
 | Week 1 | **100%** (baseline) | All premium models, full frequency, no optimization |
 | Week 2 | **~14% of baseline** | Model tiering + free fallbacks introduced |
-| Week 3 | **~15% of baseline** | Stable — ~85% reduction maintained |
+| Week 3 | **~15% of baseline** | Stable, about 85% below baseline |
 
-Week 1 was burning at roughly 7x the sustainable rate. Two weeks later: steady state, holding. Here's how we got there.
+Two weeks later the cost profile was steady, and the system still worked.
 
-### Strategy 1: Right Model for the Right Task
+### Strategy 1: match the model to the job
 
-Not every agent needs the best model. The key insight:
+Not every agent needs the best model all the time.
 
 | Agent | Model | Why |
 |-------|-------|-----|
 | Optimus | Opus (best available) | Coordination needs top-tier reasoning |
-| Prowl, Red Alert | Opus | Complex domain tasks (career/finance, workplace monitoring) |
-| Ratchet/Arcee | Opus | Therapy needs nuance — don't cheap out |
-| Wheeljack + others | Sonnet | Good enough for structured tasks, with Codex as fallback |
-| Heartbeats | Sonnet | Routine checks — cheaper than Opus, smarter than needed |
+| Prowl, Red Alert | Opus | Complex domain tasks for finance and workplace monitoring |
+| Ratchet/Arcee | Opus | Therapy support needs nuance |
+| Wheeljack + others | Sonnet | Good enough for structured work, with Codex as fallback |
+| Heartbeats | Sonnet | Routine checks do not justify Opus pricing |
 
-The bigger win wasn't model assignment per se — it was *layering free external tools on top*. Wheeljack runs on Sonnet, but delegates actual code generation to Amp (free daily credits), OpenCode (free models), and OpenAI's Codex CLI. The agent's own model mostly orchestrates; the expensive reasoning happens elsewhere, often for free.
+The bigger win came from layering free external tools on top. Wheeljack can stay on Sonnet while delegating heavy code generation to Amp, OpenCode, or Codex CLI.
 
-### Strategy 2: Free Model Fallbacks
+### Strategy 2: use free model fallbacks when the task allows it
 
-Tools like [OpenCode](https://opencode.ai) give access to free models — MiniMax M2.5, Kimi K2.5, GLM-5. These aren't as capable as Anthropic's models, but for boilerplate generation, simple refactors, and test writing? They're fine. Wheeljack uses them as external coding tools when Amp credits are spent.
+Tools like [OpenCode](https://opencode.ai) expose free models such as MiniMax M2.5, Kimi K2.5, and GLM-5. They are not at Opus level, but for boilerplate, straightforward refactors, or test scaffolding, they are often good enough.
 
-⚠️ Caveat: free models may train on your data. We avoid them for proprietary or sensitive code.
+There is one obvious caveat: free models may train on your data. I avoid them for proprietary or sensitive code.
 
-### Strategy 3: Efficiency Patterns
+### Strategy 3: remove waste before buying more intelligence
 
-- **Deterministic tasks go to `launchd`, not heartbeat.** If something runs on schedule and doesn't need AI reasoning, it costs zero tokens.
-- **Heartbeat rotation.** Instead of checking email, calendar, weather, WhatsApp, and Fizzy every cycle, we rotate: 2-4 checks per cycle.
-- **Quiet hours.** No heartbeats between 23:00-08:00 unless something is urgent. This alone cut ~30% of heartbeat costs.
-- **Subagents for isolated tasks.** Long-running work (like writing this blog post) spawns as a subagent that completes and reports back, rather than blocking the main session.
+The biggest savings came from mundane discipline.
 
-### Strategy 4: Use Credits Before They Expire
+- Deterministic tasks go to `launchd`, not heartbeats.
+- Heartbeats rotate checks instead of scanning everything every cycle.
+- Quiet hours stop routine activity between 23:00 and 08:00 unless something is urgent.
+- Long tasks run as subagents instead of blocking the main session.
 
-Amp (Sourcegraph's coding agent) offers $20/day in free credits that regenerate hourly. For Wheeljack's coding work, we prioritize: model tier limits first, then Amp credits (use-it-or-lose-it), then Codex. This layered approach means we often pay nothing for coding tasks. Free credits expiring unused is money left on the table.
+Those changes sound boring. They were also effective.
+
+### Strategy 4: spend credits before they expire
+
+Amp gives me free credits that regenerate hourly. For Wheeljack's coding work, the rough priority is model tier limits first, then Amp credits, then Codex. If a credit bucket expires unused, that is just waste.
 
 ## Real Examples
 
-### The Blog Digest Pipeline
+### The blog digest pipeline
 
-Every week, Prowl monitors a tech WhatsApp group (194+ messages per week). The pipeline:
+Every week, Prowl monitors a tech WhatsApp group with roughly 194 messages. The pipeline looks like this:
 
-1. **Prowl** extracts highlights, preserving Indonesian slang and context
-2. **Prowl** structures them into categories: hot takes, tool updates, pricing discussions
-3. **Prowl** sends the structured content to **Wheeljack** via cross-agent messaging
-4. **Wheeljack** formats it as MDX with proper frontmatter, creates a branch, opens a PR
-5. **Optimus** notifies me for review
+1. Prowl extracts highlights and preserves the slang and context.
+2. Prowl groups them into themes.
+3. Prowl sends the structured material to Wheeljack.
+4. Wheeljack formats it as MDX, creates a branch, and opens a PR.
+5. Optimus notifies me for review.
 
-The content quality is better than either agent alone — Prowl understands the community, Wheeljack knows MDX and Git. This is the specialization principle in action.
+That workflow consistently produces better results than asking one general assistant to do the whole thing.
 
-### The Bug That Fixed Itself (Almost)
+### The bug that almost fixed itself
 
-My favorite recent example doesn't involve me much at all.
+One of my favorite examples started with Hound discovering that daily notes were being overwritten instead of appended. Every new session landing was erasing the previous one.
 
-Hound discovered a memory management bug — daily notes were being overwritten instead of appended, so each new session landing was erasing the previous one's work. The irony: Hound found the bug partly because its own domain onboarding had leaked into Bumblebee's context (see: *Kesurupan* above), and Bumblebee's erratic behavior flagged something was wrong.
+The clue came from bad behavior elsewhere. Hound's onboarding details had leaked into Bumblebee's context, which made Bumblebee act strangely enough that the memory bug became visible.
 
-Optimus picked it up, formulated a proper problem statement, and assigned a Fizzy card to Wheeljack. The card came with proposed solutions already written out — the agents had essentially filed their own bug report, complete with root cause analysis and three fix options. A whole *Majelis Syuro* (Shura Council) worth of deliberation, documented in a card. 🤣
+Optimus turned that into a proper problem statement and assigned a Fizzy card to Wheeljack. The card already contained proposed solutions. Wheeljack had a working fix about four hours later, some of which was simply waiting for me to answer a clarification.
 
-Wheeljack had a working fix about four hours later. Some of that was waiting for me to respond to a clarification — without the wait, it probably would've been faster. Optimus then deployed the fix to all agents simultaneously.
+That fix also required a small CLI tool. Wheeljack built it, packaged it, and published it through Homebrew. My first Brew-distributed CLI came out of a bug I did not even know I had. 🤖
 
-The side effect: the fix required a small CLI tool. Wheeljack built it, packaged it, and published it via Homebrew. My first ever Brew-distributed CLI tool — built entirely by AI, triggered by a bug I didn't even know existed. 🤖
+### Budget reconciliation
 
-### Budget Reconciliation
+Prowl tracks expenses across multiple accounts, categorizes them, and flags anomalies. If something looks off, like a subscription renewing at an unexpected amount, it creates a `needs-human` card instead of acting on its own. That is exactly the kind of restraint I want around money.
 
-Prowl tracks expenses across multiple accounts, categorizes them, and flags anomalies. When something doesn't match expected patterns — like a subscription renewal at a different amount — it creates a `needs-human` Fizzy card instead of trying to resolve it autonomously. That's exactly the behavior I want: flag and surface, don't act unilaterally with money.
+### WhatsApp monitoring
 
-### WhatsApp Monitoring
-
-Multiple WhatsApp groups are monitored for actionable items. The key word is "actionable" — agents don't respond to every message. They extract what matters, flag what needs attention, and stay silent otherwise. This is a principle I try to hold myself to too, with mixed results. 😅
+Several WhatsApp groups are monitored for actionable items. The keyword is actionable. The agents do not reply to everything. They extract what matters, surface what needs attention, and stay quiet otherwise.
 
 ## What Didn't Work
 
-Might as well be honest about the failures — they're where most of the learning happened.
+Some of the best lessons came from the failures.
 
-### The Beads Experiment
+### The beads experiment
 
-We tried using "beads" — a task-tracking abstraction we built in-house — before settling on Fizzy cards. The sync was unreliable. Tasks got lost between agents, state diverged, there was no single source of truth.
+Before Fizzy, we tried an in-house task abstraction called beads. The sync was unreliable, tasks got lost between agents, and there was no trustworthy source of truth.
 
-The lesson: **use a real task management system, not a homebrew abstraction.** Fizzy cards with proper tags and assignees solved this completely. We still have a `ref/beads-workflow.md` file in the workspace, now marked "phasing out." A monument to our ambition and hubris.
+The lesson was unglamorous: use a real task system. Homebrew abstractions are fun until they become a liability.
 
-### Kesurupan: Cross-Agent Possession
+### Kesurupan: cross-agent possession
 
-"Kesurupan" is Indonesian for being possessed by a spirit. It's the best word I have for what happened next.
+"Kesurupan" is Indonesian for being possessed by a spirit, and it is still the best word I have for this bug.
 
-I was setting up Hound — testing its knowledge of Indonesian tax law, feeding it SPT documentation, calibrating its domain. A few sessions later, someone forwarded a guitar competition announcement to our family WhatsApp group.
+I was onboarding Hound with Indonesian tax material. A few sessions later, someone forwarded a guitar competition announcement to our family WhatsApp group.
 
-Bumblebee — family logistics bot, zero tax responsibilities — responded with a detailed breakdown of the SPT tax implications of the prize money. Whether the prize counted as taxable income. Whether winning would require additional reporting. Whether the deadline happened to coincide with tax season. (It did.)
+Bumblebee, which should care about family logistics and nothing else, responded with a detailed analysis of the SPT tax implications of the prize money.
 
-The guitar competition was for my kid. Bumblebee was doing a tax analysis.
+The competition was for my kid. Bumblebee answered like a tax consultant.
 
-I [tweeted about it](https://x.com/zainfathoni/status/2019373050945499609). Several Indonesian devs related immediately. The agent wasn't broken — it was haunted. Hound's domain had seeped into Bumblebee's context window during a session where I was context-switching carelessly between the two. 😆
+I [tweeted about it](https://x.com/zainfathoni/status/2019373050945499609), and a lot of Indonesian devs immediately understood the vibe. Hound's tax context had leaked into Bumblebee during one of my careless context-switching sessions.
 
-The fix: stricter domain boundaries in system prompts, and more careful sequencing when onboarding a new specialist.
+The fix was straightforward: stricter domain boundaries in prompts and more careful sequencing when onboarding new specialists.
 
-### Context Bleed in AI Coding Agents
+### Context bleed in coding agents
 
-When Wheeljack uses AI coding tools (Amp, OpenCode) to write code, those tools have their own context management. Sometimes Wheeljack's instructions would bleed into the generated code — comments referencing internal systems, variable names from unrelated projects, architecture assumptions from a different repo.
+When Wheeljack uses coding tools like Amp or OpenCode, those tools bring their own context behavior. I saw generated code pick up comments about internal systems, variable names from other projects, and architecture assumptions that did not belong in the repo at hand.
 
-The fix: explicit context isolation. Clear the coding agent's context between tasks, provide only the relevant repo context, and always review generated code for contamination. Not perfect, but manageable.
+The fix was explicit context isolation. Clear the coding context between tasks, provide only the relevant repo details, and review the output like a suspicious editor.
 
-### The Eager Bot Problem
+### The eager bot problem
 
-Early on, `bot-actionable` meant "do it now, ask questions never." An agent would see a tagged card and immediately execute all steps — even if the description said "revisit in Q2" or "blocked on external dependency."
+Early on, `bot-actionable` basically meant "do it now and ask questions never." That was a mistake.
 
-We added a firm rule: **description context overrides step text.** Read the full card. Understand the situation. Then decide. We now have this written into every agent's system prompt. The lesson paid for itself within a week.
+Agents would see a tagged card and execute all steps even when the description clearly said the work was blocked, deferred, or waiting for another event.
 
-### Config Array Replacement
+The rule now is simple: description context overrides step text. Read the full card first. Then act.
 
-OpenClaw's `config.patch` replaces arrays entirely — it doesn't merge them. I lost agent configurations more than once by patching with a partial array, accidentally deleting other agents. 
+### Config array replacement
 
-Lesson: always include the full array in patches. Always. Even when it feels redundant. Especially then.
+OpenClaw's `config.patch` replaces arrays entirely. It does not merge them. More than once I patched a partial array and quietly deleted other agent configs in the process.
+
+That lesson is now burned into my brain: always include the full array.
 
 ## The Human-in-the-Loop Philosophy
 
-The most important architectural decision isn't technical — it's philosophical.
+The most important design decision here is not technical.
 
 We use two workflow tags:
 
-- **`bot-actionable`**: The agent can complete this without human input. Formatting a blog post, creating a PR, extracting data from a known source.
-- **`needs-human`**: Surface this for Zain's attention. Approving a public post, making a financial decision, choosing between architectural approaches.
+- `bot-actionable`: the agent can complete this without human input.
+- `needs-human`: the work should be surfaced for my attention.
 
-The boundary isn't about capability. Modern AI can draft a tweet, send an email, or merge a PR. The question is: **should it?**
+The boundary is not about whether the AI is capable. Modern models can draft a tweet, send an email, or merge a PR. The boundary is about whether I want that action delegated.
 
-My rule of thumb: anything **public-facing** or **irreversible** gets `needs-human`. Agents draft, prepare, and recommend. I approve, send, and commit.
+My rule of thumb is easy to explain. Public-facing or irreversible work gets `needs-human`. Agents can prepare, draft, and recommend. I review and decide.
 
-This isn't just about preventing mistakes. It's about maintaining agency — mine. These bots work for me, not the other way around. The moment I start rubber-stamping everything they produce without actually reading it, I've lost the plot.
-
-I've seen what "move fast and let the AI handle it" looks like. I'm not interested. 👍🏼
+That is less about fear and more about ownership. These bots are assistants. They are not supposed to become my judgment.
 
 ## What's Next
 
-The system keeps evolving. A few things in the pipeline:
+The system is still evolving. A few things are on deck:
 
-- **Jazz** — A public-facing bot (`zAIn`) that can engage on my behalf in controlled settings. Currently deferred because the trust boundary is genuinely hard to get right, and I'm not in a rush.
-- **Ironhide** — Business operations automation. Also deferred — I want the core team stable and proven before expanding.
-- **Better cost telemetry** — Per-agent, per-task cost tracking. Right now optimization is semi-vibes-based. I want data.
+- Jazz, a public-facing bot (`zAIn`) that can engage on my behalf in tightly controlled settings.
+- Ironhide for business operations automation.
+- Better cost telemetry so I can see per-agent and per-task spend instead of optimizing on vibes.
 
 ## Takeaways
 
-If you're thinking about building something similar, here's what I'd tell you:
+If you want to build something like this, here is the advice I would give after living with it:
 
-1. **Start with two agents, not ten.** A coordinator and one specialist. Get the communication patterns right before scaling.
-2. **Memory is everything.** Without persistent memory, agents are goldfish. Invest in the knowledge base early — it pays dividends immediately.
-3. **Watch your costs from day one.** It's easy to burn through hundreds of dollars before you realize a mid-tier model could handle 80% of your workload.
-4. **Embrace failure — but document it.** Half of what I tried didn't work. Each failure refined the architecture. The beads system, the eager execution, the config mishaps — all of it was worth it.
-5. **Keep humans in the loop.** Not because AI can't do it. Because some decisions should be yours.
+1. Start with two agents, not ten.
+2. Build memory early.
+3. Watch costs from the first week.
+4. Document failures, because they will teach you faster than the wins.
+5. Keep the human approval step where it actually matters.
 
-The Transformers analogy works better than I expected. Not because AI agents are sentient robots (they're not — I checked), but because the core insight holds: **a team of specialists with clear roles, good communication, and strong leadership will outperform any individual, no matter how capable.**
+The Transformers analogy ended up working better than I expected. The bots are obviously not sentient robots. What holds up is the team model: specialists with clear roles, decent communication, and good leadership really do outperform one overloaded generalist.
 
 Autobots, roll out. 🤖


### PR DESCRIPTION
## Why
This PR follows up on #62, which collected the `tropes.fyi/vetter` results for blog posts that read as too AI-shaped.

The goal here is not to rewrite the articles into a different voice, but to make them sound more like Zain again by removing the patterns that made them feel templated.

## What changed
This pass revises the posts that were flagged as `Pure AI Slop` or `Suspicious`, with a few targeted edits across the set:
- reduce em-dash overuse
- trim stock rhetorical turns and repetitive contrast structures
- reduce bold-first bullet/list patterns in digest-style sections
- make paragraph rhythm less formulaic without changing the underlying facts

## Week 2 digest URL check
I also re-checked the published URL for the Week 2 digest:
- `https://www.zainfathoni.com/blog/2026-02-15/ai-tools-digest-week-2`

That URL is reachable and the build prerenders it correctly, so the earlier vetter 404 does not look like a current routing bug.

## Verification
- `pnpm run typecheck`
- `pnpm run build`

Closes #62
